### PR TITLE
[VE] Remove getVEFloatABI function

### DIFF
--- a/clang/lib/Driver/ToolChains/Arch/VE.cpp
+++ b/clang/lib/Driver/ToolChains/Arch/VE.cpp
@@ -18,45 +18,8 @@ using namespace clang::driver::tools;
 using namespace clang;
 using namespace llvm::opt;
 
-ve::FloatABI ve::getVEFloatABI(const Driver &D, const ArgList &Args) {
-  ve::FloatABI ABI = ve::FloatABI::Invalid;
-  if (Arg *A = Args.getLastArg(clang::driver::options::OPT_msoft_float,
-                               options::OPT_mhard_float,
-                               options::OPT_mfloat_abi_EQ)) {
-    if (A->getOption().matches(clang::driver::options::OPT_msoft_float))
-      ABI = ve::FloatABI::Soft;
-    else if (A->getOption().matches(options::OPT_mhard_float))
-      ABI = ve::FloatABI::Hard;
-    else {
-      ABI = llvm::StringSwitch<ve::FloatABI>(A->getValue())
-                .Case("soft", ve::FloatABI::Soft)
-                .Case("hard", ve::FloatABI::Hard)
-                .Default(ve::FloatABI::Invalid);
-      if (ABI == ve::FloatABI::Invalid && !StringRef(A->getValue()).empty()) {
-        D.Diag(clang::diag::err_drv_invalid_mfloat_abi) << A->getAsString(Args);
-        ABI = ve::FloatABI::Hard;
-      }
-    }
-  }
-
-  // If unspecified, choose the default based on the platform.
-  // Only the hard-float ABI on VE is standardized, and it is the
-  // default. GCC also supports a nonstandard soft-float ABI mode, also
-  // implemented in LLVM. However as this is not standard we set the default
-  // to be hard-float.
-  if (ABI == ve::FloatABI::Invalid) {
-    ABI = ve::FloatABI::Hard;
-  }
-
-  return ABI;
-}
-
 void ve::getVETargetFeatures(const Driver &D, const ArgList &Args,
                              std::vector<StringRef> &Features) {
-  ve::FloatABI FloatABI = ve::getVEFloatABI(D, Args);
-  if (FloatABI == ve::FloatABI::Soft)
-    Features.push_back("+soft-float");
-
   // Defaults.
   bool EnableVPU = true;
   bool EnableSIMD = false;

--- a/clang/lib/Driver/ToolChains/Arch/VE.h
+++ b/clang/lib/Driver/ToolChains/Arch/VE.h
@@ -20,14 +20,6 @@ namespace driver {
 namespace tools {
 namespace ve {
 
-enum class FloatABI {
-  Invalid,
-  Soft,
-  Hard,
-};
-
-FloatABI getVEFloatABI(const Driver &D, const llvm::opt::ArgList &Args);
-
 void getVETargetFeatures(const Driver &D, const llvm::opt::ArgList &Args,
                          std::vector<llvm::StringRef> &Features);
 

--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -2396,20 +2396,9 @@ void Clang::AddWebAssemblyTargetArgs(const ArgList &Args,
 }
 
 void Clang::AddVETargetArgs(const ArgList &Args, ArgStringList &CmdArgs) const {
-  ve::FloatABI FloatABI =
-      ve::getVEFloatABI(getToolChain().getDriver(), Args);
-
-  if (FloatABI == ve::FloatABI::Soft) {
-    // Floating point operations and argument passing are soft.
-    CmdArgs.push_back("-msoft-float");
-    CmdArgs.push_back("-mfloat-abi");
-    CmdArgs.push_back("soft");
-  } else {
-    // Floating point operations and argument passing are hard.
-    assert(FloatABI == ve::FloatABI::Hard && "Invalid float abi!");
-    CmdArgs.push_back("-mfloat-abi");
-    CmdArgs.push_back("hard");
-  }
+  // Floating point operations and argument passing are hard.
+  CmdArgs.push_back("-mfloat-abi");
+  CmdArgs.push_back("hard");
 }
 
 void Clang::DumpCompilationDatabase(Compilation &C, StringRef Filename,


### PR DESCRIPTION
Remove unnecessary getVEFloatABI function to make source code synchronized with upstream.

Passed internal regression tests.
