### PR TITLE
hasValue removal and setcc optimization

### DIFF
--- a/llvm/lib/IR/FPEnv.cpp
+++ b/llvm/lib/IR/FPEnv.cpp
@@ -131,7 +131,7 @@ Intrinsic::ID getConstrainedIntrinsicID(const Instruction &Instr) {
 Value *GetConstrainedFPExcept(LLVMContext &Context,
                               fp::ExceptionBehavior UseExcept) {
   Optional<StringRef> ExceptStr = convertExceptionBehaviorToStr(UseExcept);
-  assert(ExceptStr.hasValue() && "Garbage strict exception behavior!");
+  assert(ExceptStr.has_value() && "Garbage strict exception behavior!");
   auto *ExceptMDS = MDString::get(Context, ExceptStr.value());
 
   return MetadataAsValue::get(Context, ExceptMDS);
@@ -140,7 +140,7 @@ Value *GetConstrainedFPExcept(LLVMContext &Context,
 Value *GetConstrainedFPRounding(LLVMContext &Context,
                                 RoundingMode UseRounding) {
   Optional<StringRef> RoundingStr = convertRoundingModeToStr(UseRounding);
-  assert(RoundingStr.hasValue() && "Garbage strict rounding mode!");
+  assert(RoundingStr.has_value() && "Garbage strict rounding mode!");
   auto *RoundingMDS = MDString::get(Context, RoundingStr.value());
 
   return MetadataAsValue::get(Context, RoundingMDS);

--- a/llvm/lib/Target/VE/VEInstrInfo.td
+++ b/llvm/lib/Target/VE/VEInstrInfo.td
@@ -2190,42 +2190,52 @@ multiclass SETCCREGm<ValueType TY, Operand COND,
 
 // Integer setcc multiclass.
 multiclass SETCCIm<ValueType TY, RR CMOV,
-                   RR CMPIir, RR CMPIrr, RR CMPUir, RR CMPUrr> :
+                   RR CMPIir, RR CMPIrm, RR CMPIrr,
+                   RR CMPUir, RR CMPUrm, RR CMPUrr> :
   // Avoid CMP instruction iff rhs == 0 and signed comparison.
   SETCCZEROm<TY, zero, CCSIOp, CMOV, icond2cc>,
   // Instrument immediate value in CMP instruction.  VE uses LHS but llvm uses
   // RHS, so we swap them and use calculate condition code with swap
   SETCCIMMm<TY, simm7, CCSIOp, CMOV, icond2ccSwap, (CMPIir (LO7 $r), $l)>,
   SETCCIMMm<TY, simm7, CCUIOp, CMOV, icond2ccSwap, (CMPUir (LO7 $r), $l)>,
+  // Instrument another format of immediate value in CMP instruction.
+  SETCCIMMm<TY, mimm, CCSIOp, CMOV, icond2cc, (CMPIrm $l, (MIMM $r))>,
+  SETCCIMMm<TY, mimm, CCUIOp, CMOV, icond2cc, (CMPUrm $l, (MIMM $r))>,
   // Otherwise, we use generic register comparison.
   SETCCREGm<TY, CCSIOp, CMOV, icond2cc, (CMPIrr $l, $r)>,
   SETCCREGm<TY, CCUIOp, CMOV, icond2cc, (CMPUrr $l, $r)>;
 
 // Floating point setcc multiclass.
-multiclass SETCCFm<ValueType TY, RR CMOV, RR CMPir, RR CMPrr> :
+multiclass SETCCFm<ValueType TY, RR CMOV, RR CMPir, RR CMPrm, RR CMPrr> :
   // Avoid CMP instruction iff rhs == 0 and no-nans.
   SETCCZEROm<TY, fpzero, cond, CMOV, fcond2cc>,
   // Instrument immediate value in CMP instruction.  VE uses LHS but llvm uses
   // RHS, so we swap them and use calculate condition code with swap
   SETCCIMMm<TY, simm7fp, cond, CMOV, fcond2ccSwap, (CMPir (LO7FP $r), $l)>,
+  // Instrument another format of immediate value in CMP instruction.
+  SETCCIMMm<TY, mimmfp, cond, CMOV, fcond2cc, (CMPrm $l, (MIMMFP $r))>,
   // Otherwise, we use generic register comparison.
   SETCCREGm<TY, cond, CMOV, fcond2cc, (CMPrr $l, $r)>;
 
-multiclass SETCCF128m<ValueType TY, RR CMOV, RR CMPir, RR CMPrr> :
+multiclass SETCCF128m<ValueType TY, RR CMOV, RR CMPir, RR CMPrm, RR CMPrr> :
   // Avoiding CMP instruction is not possible for f128 since VE's CMOV uses
   // a f64 result of a f128 comparison.
 
   // Instrument immediate value in CMP instruction.  VE uses LHS but llvm uses
   // RHS, so we swap them and use calculate condition code with swap
   SETCCIMMm<TY, simm7fp, cond, CMOV, fcond2ccSwap, (CMPir (LO7FP $r), $l)>,
+  // Instrument another format of immediate value in CMP instruction.
+  SETCCIMMm<TY, mimmfp, cond, CMOV, fcond2cc, (CMPrm $l, (MIMMFP $r))>,
   // Otherwise, we use generic register comparison.
   SETCCREGm<TY, cond, CMOV, fcond2cc, (CMPrr $l, $r)>;
 
-defm : SETCCIm<i32, CMOVWrm, CMPSWSXir, CMPSWSXrr, CMPUWir, CMPUWrr>;
-defm : SETCCIm<i64, CMOVLrm, CMPSLir, CMPSLrr, CMPULir, CMPULrr>;
-defm : SETCCFm<f32, CMOVSrm, FCMPSir, FCMPSrr>;
-defm : SETCCFm<f64, CMOVDrm, FCMPDir, FCMPDrr>;
-defm : SETCCF128m<f128, CMOVDrm, FCMPQir, FCMPQrr>;
+defm : SETCCIm<i32, CMOVWrm, CMPSWSXir, CMPSWSXrm, CMPSWSXrr, CMPUWir,
+               CMPUWrm, CMPUWrr>;
+defm : SETCCIm<i64, CMOVLrm, CMPSLir, CMPSLrm, CMPSLrr, CMPULir, CMPULrm,
+               CMPULrr>;
+defm : SETCCFm<f32, CMOVSrm, FCMPSir, FCMPSrm, FCMPSrr>;
+defm : SETCCFm<f64, CMOVDrm, FCMPDir, FCMPDrm, FCMPDrr>;
+defm : SETCCF128m<f128, CMOVDrm, FCMPQir, FCMPQrm, FCMPQrr>;
 
 // Generic CMOV pattern matches
 //   CMOV accepts i64 $t, $f, and result.  So, we extend it to support

--- a/llvm/test/CodeGen/VE/Scalar/selectcc_dcomp.ll
+++ b/llvm/test/CodeGen/VE/Scalar/selectcc_dcomp.ll
@@ -1124,8 +1124,7 @@ define { fp128, fp128 } @func_dcomp_qcomp_i(double %0, double %1, fp128 %2, fp12
 define zeroext i1 @func_dcomp_1_m(double %0, double %1, i1 zeroext %2, i1 zeroext %3) {
 ; CHECK-LABEL: func_dcomp_1_m:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    lea.sl %s4, -1073741824
-; CHECK-NEXT:    fcmp.d %s0, %s0, %s4
+; CHECK-NEXT:    fcmp.d %s0, %s0, (2)1
 ; CHECK-NEXT:    or %s4, 0, (0)1
 ; CHECK-NEXT:    or %s5, 0, (0)1
 ; CHECK-NEXT:    cmov.d.eq %s5, (63)0, %s0
@@ -1145,8 +1144,7 @@ define zeroext i1 @func_dcomp_1_m(double %0, double %1, i1 zeroext %2, i1 zeroex
 define signext i8 @func_dcomp_8_m(double %0, double %1, i8 signext %2, i8 signext %3) {
 ; CHECK-LABEL: func_dcomp_8_m:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    lea.sl %s4, -1073741824
-; CHECK-NEXT:    fcmp.d %s0, %s0, %s4
+; CHECK-NEXT:    fcmp.d %s0, %s0, (2)1
 ; CHECK-NEXT:    or %s4, 0, (0)1
 ; CHECK-NEXT:    or %s5, 0, (0)1
 ; CHECK-NEXT:    cmov.d.eq %s5, (63)0, %s0
@@ -1166,8 +1164,7 @@ define signext i8 @func_dcomp_8_m(double %0, double %1, i8 signext %2, i8 signex
 define zeroext i8 @func_dcomp_u8_m(double %0, double %1, i8 zeroext %2, i8 zeroext %3) {
 ; CHECK-LABEL: func_dcomp_u8_m:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    lea.sl %s4, -1073741824
-; CHECK-NEXT:    fcmp.d %s0, %s0, %s4
+; CHECK-NEXT:    fcmp.d %s0, %s0, (2)1
 ; CHECK-NEXT:    or %s4, 0, (0)1
 ; CHECK-NEXT:    or %s5, 0, (0)1
 ; CHECK-NEXT:    cmov.d.eq %s5, (63)0, %s0
@@ -1187,8 +1184,7 @@ define zeroext i8 @func_dcomp_u8_m(double %0, double %1, i8 zeroext %2, i8 zeroe
 define signext i16 @func_dcomp_16_m(double %0, double %1, i16 signext %2, i16 signext %3) {
 ; CHECK-LABEL: func_dcomp_16_m:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    lea.sl %s4, -1073741824
-; CHECK-NEXT:    fcmp.d %s0, %s0, %s4
+; CHECK-NEXT:    fcmp.d %s0, %s0, (2)1
 ; CHECK-NEXT:    or %s4, 0, (0)1
 ; CHECK-NEXT:    or %s5, 0, (0)1
 ; CHECK-NEXT:    cmov.d.eq %s5, (63)0, %s0
@@ -1208,8 +1204,7 @@ define signext i16 @func_dcomp_16_m(double %0, double %1, i16 signext %2, i16 si
 define zeroext i16 @func_dcomp_u16_m(double %0, double %1, i16 zeroext %2, i16 zeroext %3) {
 ; CHECK-LABEL: func_dcomp_u16_m:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    lea.sl %s4, -1073741824
-; CHECK-NEXT:    fcmp.d %s0, %s0, %s4
+; CHECK-NEXT:    fcmp.d %s0, %s0, (2)1
 ; CHECK-NEXT:    or %s4, 0, (0)1
 ; CHECK-NEXT:    or %s5, 0, (0)1
 ; CHECK-NEXT:    cmov.d.eq %s5, (63)0, %s0
@@ -1229,8 +1224,7 @@ define zeroext i16 @func_dcomp_u16_m(double %0, double %1, i16 zeroext %2, i16 z
 define signext i32 @func_dcomp_32_m(double %0, double %1, i32 signext %2, i32 signext %3) {
 ; CHECK-LABEL: func_dcomp_32_m:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    lea.sl %s4, -1073741824
-; CHECK-NEXT:    fcmp.d %s0, %s0, %s4
+; CHECK-NEXT:    fcmp.d %s0, %s0, (2)1
 ; CHECK-NEXT:    or %s4, 0, (0)1
 ; CHECK-NEXT:    or %s5, 0, (0)1
 ; CHECK-NEXT:    cmov.d.eq %s5, (63)0, %s0
@@ -1250,8 +1244,7 @@ define signext i32 @func_dcomp_32_m(double %0, double %1, i32 signext %2, i32 si
 define zeroext i32 @func_dcomp_u32_m(double %0, double %1, i32 zeroext %2, i32 zeroext %3) {
 ; CHECK-LABEL: func_dcomp_u32_m:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    lea.sl %s4, -1073741824
-; CHECK-NEXT:    fcmp.d %s0, %s0, %s4
+; CHECK-NEXT:    fcmp.d %s0, %s0, (2)1
 ; CHECK-NEXT:    or %s4, 0, (0)1
 ; CHECK-NEXT:    or %s5, 0, (0)1
 ; CHECK-NEXT:    cmov.d.eq %s5, (63)0, %s0
@@ -1271,8 +1264,7 @@ define zeroext i32 @func_dcomp_u32_m(double %0, double %1, i32 zeroext %2, i32 z
 define i64 @func_dcomp_64_m(double %0, double %1, i64 %2, i64 %3) {
 ; CHECK-LABEL: func_dcomp_64_m:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    lea.sl %s4, -1073741824
-; CHECK-NEXT:    fcmp.d %s0, %s0, %s4
+; CHECK-NEXT:    fcmp.d %s0, %s0, (2)1
 ; CHECK-NEXT:    or %s4, 0, (0)1
 ; CHECK-NEXT:    or %s5, 0, (0)1
 ; CHECK-NEXT:    cmov.d.eq %s5, (63)0, %s0
@@ -1292,8 +1284,7 @@ define i64 @func_dcomp_64_m(double %0, double %1, i64 %2, i64 %3) {
 define i64 @func_dcomp_u64_m(double %0, double %1, i64 %2, i64 %3) {
 ; CHECK-LABEL: func_dcomp_u64_m:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    lea.sl %s4, -1073741824
-; CHECK-NEXT:    fcmp.d %s0, %s0, %s4
+; CHECK-NEXT:    fcmp.d %s0, %s0, (2)1
 ; CHECK-NEXT:    or %s4, 0, (0)1
 ; CHECK-NEXT:    or %s5, 0, (0)1
 ; CHECK-NEXT:    cmov.d.eq %s5, (63)0, %s0
@@ -1313,8 +1304,7 @@ define i64 @func_dcomp_u64_m(double %0, double %1, i64 %2, i64 %3) {
 define i128 @func_dcomp_128_m(double %0, double %1, i128 %2, i128 %3) {
 ; CHECK-LABEL: func_dcomp_128_m:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    lea.sl %s6, -1073741824
-; CHECK-NEXT:    fcmp.d %s0, %s0, %s6
+; CHECK-NEXT:    fcmp.d %s0, %s0, (2)1
 ; CHECK-NEXT:    or %s6, 0, (0)1
 ; CHECK-NEXT:    or %s7, 0, (0)1
 ; CHECK-NEXT:    cmov.d.eq %s7, (63)0, %s0
@@ -1336,8 +1326,7 @@ define i128 @func_dcomp_128_m(double %0, double %1, i128 %2, i128 %3) {
 define i128 @func_dcomp_u128_m(double %0, double %1, i128 %2, i128 %3) {
 ; CHECK-LABEL: func_dcomp_u128_m:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    lea.sl %s6, -1073741824
-; CHECK-NEXT:    fcmp.d %s0, %s0, %s6
+; CHECK-NEXT:    fcmp.d %s0, %s0, (2)1
 ; CHECK-NEXT:    or %s6, 0, (0)1
 ; CHECK-NEXT:    or %s7, 0, (0)1
 ; CHECK-NEXT:    cmov.d.eq %s7, (63)0, %s0
@@ -1359,8 +1348,7 @@ define i128 @func_dcomp_u128_m(double %0, double %1, i128 %2, i128 %3) {
 define float @func_dcomp_float_m(double %0, double %1, float %2, float %3) {
 ; CHECK-LABEL: func_dcomp_float_m:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    lea.sl %s4, -1073741824
-; CHECK-NEXT:    fcmp.d %s0, %s0, %s4
+; CHECK-NEXT:    fcmp.d %s0, %s0, (2)1
 ; CHECK-NEXT:    or %s4, 0, (0)1
 ; CHECK-NEXT:    or %s5, 0, (0)1
 ; CHECK-NEXT:    cmov.d.eq %s5, (63)0, %s0
@@ -1380,8 +1368,7 @@ define float @func_dcomp_float_m(double %0, double %1, float %2, float %3) {
 define double @func_dcomp_double_m(double %0, double %1, double %2, double %3) {
 ; CHECK-LABEL: func_dcomp_double_m:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    lea.sl %s4, -1073741824
-; CHECK-NEXT:    fcmp.d %s0, %s0, %s4
+; CHECK-NEXT:    fcmp.d %s0, %s0, (2)1
 ; CHECK-NEXT:    or %s4, 0, (0)1
 ; CHECK-NEXT:    or %s5, 0, (0)1
 ; CHECK-NEXT:    cmov.d.eq %s5, (63)0, %s0
@@ -1401,8 +1388,7 @@ define double @func_dcomp_double_m(double %0, double %1, double %2, double %3) {
 define fp128 @func_dcomp_quad_m(double %0, double %1, fp128 %2, fp128 %3) {
 ; CHECK-LABEL: func_dcomp_quad_m:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    lea.sl %s6, -1073741824
-; CHECK-NEXT:    fcmp.d %s0, %s0, %s6
+; CHECK-NEXT:    fcmp.d %s0, %s0, (2)1
 ; CHECK-NEXT:    or %s6, 0, (0)1
 ; CHECK-NEXT:    or %s7, 0, (0)1
 ; CHECK-NEXT:    cmov.d.eq %s7, (63)0, %s0
@@ -1424,8 +1410,7 @@ define fp128 @func_dcomp_quad_m(double %0, double %1, fp128 %2, fp128 %3) {
 define { float, float } @func_dcomp_fcomp_m(double %0, double %1, float %2, float %3, float %4, float %5) {
 ; CHECK-LABEL: func_dcomp_fcomp_m:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    lea.sl %s6, -1073741824
-; CHECK-NEXT:    fcmp.d %s0, %s0, %s6
+; CHECK-NEXT:    fcmp.d %s0, %s0, (2)1
 ; CHECK-NEXT:    or %s6, 0, (0)1
 ; CHECK-NEXT:    or %s7, 0, (0)1
 ; CHECK-NEXT:    cmov.d.eq %s7, (63)0, %s0
@@ -1450,8 +1435,7 @@ define { float, float } @func_dcomp_fcomp_m(double %0, double %1, float %2, floa
 define { double, double } @func_dcomp_dcomp_m(double %0, double %1, double %2, double %3, double %4, double %5) {
 ; CHECK-LABEL: func_dcomp_dcomp_m:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    lea.sl %s6, -1073741824
-; CHECK-NEXT:    fcmp.d %s0, %s0, %s6
+; CHECK-NEXT:    fcmp.d %s0, %s0, (2)1
 ; CHECK-NEXT:    or %s6, 0, (0)1
 ; CHECK-NEXT:    or %s7, 0, (0)1
 ; CHECK-NEXT:    cmov.d.eq %s7, (63)0, %s0
@@ -1478,8 +1462,7 @@ define { fp128, fp128 } @func_dcomp_qcomp_m(double %0, double %1, fp128 %2, fp12
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    ld %s35, 240(, %s11)
 ; CHECK-NEXT:    ld %s34, 248(, %s11)
-; CHECK-NEXT:    lea.sl %s36, -1073741824
-; CHECK-NEXT:    fcmp.d %s0, %s0, %s36
+; CHECK-NEXT:    fcmp.d %s0, %s0, (2)1
 ; CHECK-NEXT:    or %s36, 0, (0)1
 ; CHECK-NEXT:    or %s37, 0, (0)1
 ; CHECK-NEXT:    cmov.d.eq %s37, (63)0, %s0

--- a/llvm/test/CodeGen/VE/Scalar/selectcc_fcomp.ll
+++ b/llvm/test/CodeGen/VE/Scalar/selectcc_fcomp.ll
@@ -1124,8 +1124,7 @@ define { fp128, fp128 } @func_fcomp_qcomp_i(float %0, float %1, fp128 %2, fp128 
 define zeroext i1 @func_fcomp_1_m(float %0, float %1, i1 zeroext %2, i1 zeroext %3) {
 ; CHECK-LABEL: func_fcomp_1_m:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    lea.sl %s4, -1073741824
-; CHECK-NEXT:    fcmp.s %s0, %s0, %s4
+; CHECK-NEXT:    fcmp.s %s0, %s0, (2)1
 ; CHECK-NEXT:    or %s4, 0, (0)1
 ; CHECK-NEXT:    or %s5, 0, (0)1
 ; CHECK-NEXT:    cmov.s.eq %s5, (63)0, %s0
@@ -1145,8 +1144,7 @@ define zeroext i1 @func_fcomp_1_m(float %0, float %1, i1 zeroext %2, i1 zeroext 
 define signext i8 @func_fcomp_8_m(float %0, float %1, i8 signext %2, i8 signext %3) {
 ; CHECK-LABEL: func_fcomp_8_m:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    lea.sl %s4, -1073741824
-; CHECK-NEXT:    fcmp.s %s0, %s0, %s4
+; CHECK-NEXT:    fcmp.s %s0, %s0, (2)1
 ; CHECK-NEXT:    or %s4, 0, (0)1
 ; CHECK-NEXT:    or %s5, 0, (0)1
 ; CHECK-NEXT:    cmov.s.eq %s5, (63)0, %s0
@@ -1166,8 +1164,7 @@ define signext i8 @func_fcomp_8_m(float %0, float %1, i8 signext %2, i8 signext 
 define zeroext i8 @func_fcomp_u8_m(float %0, float %1, i8 zeroext %2, i8 zeroext %3) {
 ; CHECK-LABEL: func_fcomp_u8_m:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    lea.sl %s4, -1073741824
-; CHECK-NEXT:    fcmp.s %s0, %s0, %s4
+; CHECK-NEXT:    fcmp.s %s0, %s0, (2)1
 ; CHECK-NEXT:    or %s4, 0, (0)1
 ; CHECK-NEXT:    or %s5, 0, (0)1
 ; CHECK-NEXT:    cmov.s.eq %s5, (63)0, %s0
@@ -1187,8 +1184,7 @@ define zeroext i8 @func_fcomp_u8_m(float %0, float %1, i8 zeroext %2, i8 zeroext
 define signext i16 @func_fcomp_16_m(float %0, float %1, i16 signext %2, i16 signext %3) {
 ; CHECK-LABEL: func_fcomp_16_m:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    lea.sl %s4, -1073741824
-; CHECK-NEXT:    fcmp.s %s0, %s0, %s4
+; CHECK-NEXT:    fcmp.s %s0, %s0, (2)1
 ; CHECK-NEXT:    or %s4, 0, (0)1
 ; CHECK-NEXT:    or %s5, 0, (0)1
 ; CHECK-NEXT:    cmov.s.eq %s5, (63)0, %s0
@@ -1208,8 +1204,7 @@ define signext i16 @func_fcomp_16_m(float %0, float %1, i16 signext %2, i16 sign
 define zeroext i16 @func_fcomp_u16_m(float %0, float %1, i16 zeroext %2, i16 zeroext %3) {
 ; CHECK-LABEL: func_fcomp_u16_m:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    lea.sl %s4, -1073741824
-; CHECK-NEXT:    fcmp.s %s0, %s0, %s4
+; CHECK-NEXT:    fcmp.s %s0, %s0, (2)1
 ; CHECK-NEXT:    or %s4, 0, (0)1
 ; CHECK-NEXT:    or %s5, 0, (0)1
 ; CHECK-NEXT:    cmov.s.eq %s5, (63)0, %s0
@@ -1229,8 +1224,7 @@ define zeroext i16 @func_fcomp_u16_m(float %0, float %1, i16 zeroext %2, i16 zer
 define signext i32 @func_fcomp_32_m(float %0, float %1, i32 signext %2, i32 signext %3) {
 ; CHECK-LABEL: func_fcomp_32_m:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    lea.sl %s4, -1073741824
-; CHECK-NEXT:    fcmp.s %s0, %s0, %s4
+; CHECK-NEXT:    fcmp.s %s0, %s0, (2)1
 ; CHECK-NEXT:    or %s4, 0, (0)1
 ; CHECK-NEXT:    or %s5, 0, (0)1
 ; CHECK-NEXT:    cmov.s.eq %s5, (63)0, %s0
@@ -1250,8 +1244,7 @@ define signext i32 @func_fcomp_32_m(float %0, float %1, i32 signext %2, i32 sign
 define zeroext i32 @func_fcomp_u32_m(float %0, float %1, i32 zeroext %2, i32 zeroext %3) {
 ; CHECK-LABEL: func_fcomp_u32_m:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    lea.sl %s4, -1073741824
-; CHECK-NEXT:    fcmp.s %s0, %s0, %s4
+; CHECK-NEXT:    fcmp.s %s0, %s0, (2)1
 ; CHECK-NEXT:    or %s4, 0, (0)1
 ; CHECK-NEXT:    or %s5, 0, (0)1
 ; CHECK-NEXT:    cmov.s.eq %s5, (63)0, %s0
@@ -1271,8 +1264,7 @@ define zeroext i32 @func_fcomp_u32_m(float %0, float %1, i32 zeroext %2, i32 zer
 define i64 @func_fcomp_64_m(float %0, float %1, i64 %2, i64 %3) {
 ; CHECK-LABEL: func_fcomp_64_m:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    lea.sl %s4, -1073741824
-; CHECK-NEXT:    fcmp.s %s0, %s0, %s4
+; CHECK-NEXT:    fcmp.s %s0, %s0, (2)1
 ; CHECK-NEXT:    or %s4, 0, (0)1
 ; CHECK-NEXT:    or %s5, 0, (0)1
 ; CHECK-NEXT:    cmov.s.eq %s5, (63)0, %s0
@@ -1292,8 +1284,7 @@ define i64 @func_fcomp_64_m(float %0, float %1, i64 %2, i64 %3) {
 define i64 @func_fcomp_u64_m(float %0, float %1, i64 %2, i64 %3) {
 ; CHECK-LABEL: func_fcomp_u64_m:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    lea.sl %s4, -1073741824
-; CHECK-NEXT:    fcmp.s %s0, %s0, %s4
+; CHECK-NEXT:    fcmp.s %s0, %s0, (2)1
 ; CHECK-NEXT:    or %s4, 0, (0)1
 ; CHECK-NEXT:    or %s5, 0, (0)1
 ; CHECK-NEXT:    cmov.s.eq %s5, (63)0, %s0
@@ -1313,8 +1304,7 @@ define i64 @func_fcomp_u64_m(float %0, float %1, i64 %2, i64 %3) {
 define i128 @func_fcomp_128_m(float %0, float %1, i128 %2, i128 %3) {
 ; CHECK-LABEL: func_fcomp_128_m:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    lea.sl %s6, -1073741824
-; CHECK-NEXT:    fcmp.s %s0, %s0, %s6
+; CHECK-NEXT:    fcmp.s %s0, %s0, (2)1
 ; CHECK-NEXT:    or %s6, 0, (0)1
 ; CHECK-NEXT:    or %s7, 0, (0)1
 ; CHECK-NEXT:    cmov.s.eq %s7, (63)0, %s0
@@ -1336,8 +1326,7 @@ define i128 @func_fcomp_128_m(float %0, float %1, i128 %2, i128 %3) {
 define i128 @func_fcomp_u128_m(float %0, float %1, i128 %2, i128 %3) {
 ; CHECK-LABEL: func_fcomp_u128_m:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    lea.sl %s6, -1073741824
-; CHECK-NEXT:    fcmp.s %s0, %s0, %s6
+; CHECK-NEXT:    fcmp.s %s0, %s0, (2)1
 ; CHECK-NEXT:    or %s6, 0, (0)1
 ; CHECK-NEXT:    or %s7, 0, (0)1
 ; CHECK-NEXT:    cmov.s.eq %s7, (63)0, %s0
@@ -1359,8 +1348,7 @@ define i128 @func_fcomp_u128_m(float %0, float %1, i128 %2, i128 %3) {
 define float @func_fcomp_float_m(float %0, float %1, float %2, float %3) {
 ; CHECK-LABEL: func_fcomp_float_m:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    lea.sl %s4, -1073741824
-; CHECK-NEXT:    fcmp.s %s0, %s0, %s4
+; CHECK-NEXT:    fcmp.s %s0, %s0, (2)1
 ; CHECK-NEXT:    or %s4, 0, (0)1
 ; CHECK-NEXT:    or %s5, 0, (0)1
 ; CHECK-NEXT:    cmov.s.eq %s5, (63)0, %s0
@@ -1380,8 +1368,7 @@ define float @func_fcomp_float_m(float %0, float %1, float %2, float %3) {
 define double @func_fcomp_double_m(float %0, float %1, double %2, double %3) {
 ; CHECK-LABEL: func_fcomp_double_m:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    lea.sl %s4, -1073741824
-; CHECK-NEXT:    fcmp.s %s0, %s0, %s4
+; CHECK-NEXT:    fcmp.s %s0, %s0, (2)1
 ; CHECK-NEXT:    or %s4, 0, (0)1
 ; CHECK-NEXT:    or %s5, 0, (0)1
 ; CHECK-NEXT:    cmov.s.eq %s5, (63)0, %s0
@@ -1401,8 +1388,7 @@ define double @func_fcomp_double_m(float %0, float %1, double %2, double %3) {
 define fp128 @func_fcomp_quad_m(float %0, float %1, fp128 %2, fp128 %3) {
 ; CHECK-LABEL: func_fcomp_quad_m:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    lea.sl %s6, -1073741824
-; CHECK-NEXT:    fcmp.s %s0, %s0, %s6
+; CHECK-NEXT:    fcmp.s %s0, %s0, (2)1
 ; CHECK-NEXT:    or %s6, 0, (0)1
 ; CHECK-NEXT:    or %s7, 0, (0)1
 ; CHECK-NEXT:    cmov.s.eq %s7, (63)0, %s0
@@ -1424,8 +1410,7 @@ define fp128 @func_fcomp_quad_m(float %0, float %1, fp128 %2, fp128 %3) {
 define { float, float } @func_fcomp_fcomp_m(float %0, float %1, float %2, float %3, float %4, float %5) {
 ; CHECK-LABEL: func_fcomp_fcomp_m:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    lea.sl %s6, -1073741824
-; CHECK-NEXT:    fcmp.s %s0, %s0, %s6
+; CHECK-NEXT:    fcmp.s %s0, %s0, (2)1
 ; CHECK-NEXT:    or %s6, 0, (0)1
 ; CHECK-NEXT:    or %s7, 0, (0)1
 ; CHECK-NEXT:    cmov.s.eq %s7, (63)0, %s0
@@ -1450,8 +1435,7 @@ define { float, float } @func_fcomp_fcomp_m(float %0, float %1, float %2, float 
 define { double, double } @func_fcomp_dcomp_m(float %0, float %1, double %2, double %3, double %4, double %5) {
 ; CHECK-LABEL: func_fcomp_dcomp_m:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    lea.sl %s6, -1073741824
-; CHECK-NEXT:    fcmp.s %s0, %s0, %s6
+; CHECK-NEXT:    fcmp.s %s0, %s0, (2)1
 ; CHECK-NEXT:    or %s6, 0, (0)1
 ; CHECK-NEXT:    or %s7, 0, (0)1
 ; CHECK-NEXT:    cmov.s.eq %s7, (63)0, %s0
@@ -1478,8 +1462,7 @@ define { fp128, fp128 } @func_fcomp_qcomp_m(float %0, float %1, fp128 %2, fp128 
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    ld %s35, 240(, %s11)
 ; CHECK-NEXT:    ld %s34, 248(, %s11)
-; CHECK-NEXT:    lea.sl %s36, -1073741824
-; CHECK-NEXT:    fcmp.s %s0, %s0, %s36
+; CHECK-NEXT:    fcmp.s %s0, %s0, (2)1
 ; CHECK-NEXT:    or %s36, 0, (0)1
 ; CHECK-NEXT:    or %s37, 0, (0)1
 ; CHECK-NEXT:    cmov.s.eq %s37, (63)0, %s0


### PR DESCRIPTION
Change to follow upstream's hasValue removal.
Also, optimize setcc in VEInstrInfo.td.

This patch has been passed internal regression tests.