### PR TITLE
[VE] Update clang cache for VE

### DIFF
--- a/clang/cmake/caches/VectorEngine.cmake
+++ b/clang/cmake/caches/VectorEngine.cmake
@@ -1,16 +1,33 @@
 # This file sets up a CMakeCache for the simple VE build.
 
+# Disable TERMINFO, ZLIB, and ZSTD for VE since there is not pre-compiled
+# libraries.
+set(LLVM_ENABLE_TERMINFO OFF CACHE BOOL "")
+set(LLVM_ENABLE_ZLIB OFF CACHE BOOL "")
+set(LLVM_ENABLE_ZSTD OFF CACHE BOOL "")
+
 # The lld is not supported for VE yet.
 set(LLVM_ENABLE_PROJECTS "clang;clang-tools-extra;lld" CACHE STRING "")
 set(LLVM_ENABLE_RUNTIMES "compiler-rt;libcxx;libcxxabi;libunwind;openmp" CACHE STRING "")
 
 # Compile for X86 and VE
-set(LLVM_TARGETS_TO_BUILD X86 CACHE STRING "")
-set(LLVM_EXPERIMENTAL_TARGETS_TO_BUILD VE CACHE STRING "")
+set(LLVM_TARGETS_TO_BUILD "X86;VE" CACHE STRING "")
 
 # Not use default here to use RUNTIMES_x86_64-unknown-linux-gnu_* variables.
 set(LLVM_BUILTIN_TARGETS "x86_64-unknown-linux-gnu;ve-unknown-linux-gnu" CACHE STRING "")
 set(LLVM_RUNTIME_TARGETS "x86_64-unknown-linux-gnu;ve-unknown-linux-gnu" CACHE STRING "")
+
+# For the case of X86, we don't want to test compiler-rt for x86,
+# so disable them as much as possible.
+set(RUNTIMES_x86_64-unknown-linux-gnu_COMPILER_RT_BUILD_BUILTINS ON CACHE BOOL "")
+set(RUNTIMES_x86_64-unknown-linux-gnu_COMPILER_RT_BUILD_CRT OFF CACHE BOOL "")
+set(RUNTIMES_x86_64-unknown-linux-gnu_COMPILER_RT_BUILD_SANITIZERS OFF CACHE BOOL "")
+set(RUNTIMES_x86_64-unknown-linux-gnu_COMPILER_RT_BUILD_XRAY OFF CACHE BOOL "")
+set(RUNTIMES_x86_64-unknown-linux-gnu_COMPILER_RT_BUILD_LIBFUZZER OFF CACHE BOOL "")
+set(RUNTIMES_x86_64-unknown-linux-gnu_COMPILER_RT_BUILD_PROFILE OFF CACHE BOOL "")
+set(RUNTIMES_x86_64-unknown-linux-gnu_COMPILER_RT_BUILD_MEMPROF OFF CACHE BOOL "")
+set(RUNTIMES_x86_64-unknown-linux-gnu_COMPILER_RT_BUILD_ORC OFF CACHE BOOL "")
+set(RUNTIMES_x86_64-unknown-linux-gnu_COMPILER_RT_BUILD_GWP_ASAN OFF CACHE BOOL "")
 
 # VE supports builtins, crt, and profile only.
 set(RUNTIMES_ve-unknown-linux-gnu_COMPILER_RT_BUILD_BUILTINS ON CACHE BOOL "")
@@ -47,7 +64,7 @@ set(RUNTIMES_ve-unknown-linux-gnu_OPENMP_LIBDIR_SUFFIX "/ve-unknown-linux-gnu" C
 # VE cannot use libomptarget profiling since libomptarget uses host's profiling.
 set(RUNTIMES_ve-unknown-linux-gnu_OPENMP_ENABLE_LIBOMPTARGET_PROFILING FALSE CACHE BOOL "")
 
-# VE requires -lrt for shm_open.
+# VE requires -lrt flag for shm_open.
 set(RUNTIMES_ve-unknown-linux-gnu_LIBOMP_HAVE_SHM_OPEN_WITH_LRT TRUE CACHE BOOL "")
 
 # setup toolchain


### PR DESCRIPTION
Update clang cache for VE after merging https://reviews.llvm.org/D153989. Originally, we are waiting for https://reviews.llvm.org/D89492.  This is implemented by different way in the first patch.  Now we can compile llvm for VE by one step build like below.
  $ cmake -G Ninja ... -C clang/cmake/caches/VectorEngine.cmake
  $ ninja