### PR TITLE
[VE] Disable compiling libomptarget for VE

### DIFF
--- a/clang/cmake/caches/VectorEngine.cmake
+++ b/clang/cmake/caches/VectorEngine.cmake
@@ -63,6 +63,14 @@ set(RUNTIMES_ve-unknown-linux-gnu_OPENMP_LIBDIR_SUFFIX "/ve-unknown-linux-gnu" C
 
 # VE cannot use libomptarget profiling since libomptarget uses host's profiling.
 set(RUNTIMES_ve-unknown-linux-gnu_OPENMP_ENABLE_LIBOMPTARGET_PROFILING FALSE CACHE BOOL "")
+# Around 2022/8, libomptarget is changed to use target's libLLVM.  However,
+# our compiling mechanism supports compiling only either host's libLLVM or
+# target's libLLVM.  Therefore, it is not possible to compile host's libLLVM
+# and target's libomptarget.  Around 2023/7, libomptarget for VE is removed
+# because of the lack of tests.  So, disable libomptarget for VE also.  In
+# order to recover this, it is required to support new nextgen libomptarget
+# interface and to change make script to generate target's libLLVM.
+set(RUNTIMES_ve-unknown-linux-gnu_OPENMP_ENABLE_LIBOMPTARGET FALSE CACHE BOOL "")
 
 # VE requires -lrt flag for shm_open.
 set(RUNTIMES_ve-unknown-linux-gnu_LIBOMP_HAVE_SHM_OPEN_WITH_LRT TRUE CACHE BOOL "")


### PR DESCRIPTION
Disable compiling libomptarget for VE in the clang cache file.