### PR TITLE
[VE] Enable _BitInt support and remove futex.h workaround

### DIFF
--- a/clang/lib/Basic/Targets/VE.h
+++ b/clang/lib/Basic/Targets/VE.h
@@ -53,6 +53,8 @@ public:
 
   bool hasSjLjLowering() const override { return true; }
 
+  bool hasBitIntType() const override { return true; }
+
   llvm::SmallVector<Builtin::InfosShard> getTargetBuiltins() const override;
 
   BuiltinVaListKind getBuiltinVaListKind() const override {

--- a/libcxx/include/bitset
+++ b/libcxx/include/bitset
@@ -877,10 +877,7 @@ bitset<_Size>::to_string(char __zero, char __one) const {
 
 template <size_t _Size>
 inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX23 size_t bitset<_Size>::count() const _NOEXCEPT {
-// C23 requires __BITINT_MAXWIDTH__ to be defined, so clang defines it
-// unconditionally, even on targets where _BitInt is not supported.
-// VE does not support _BitInt (hasBitIntType() returns false), so exclude it.
-#  if defined(_LIBCPP_COMPILER_CLANG_BASED) && !defined(_LIBCPP_CXX03_LANG) && defined(__BITINT_MAXWIDTH__) && !defined(__ve__)
+#  if defined(_LIBCPP_COMPILER_CLANG_BASED) && !defined(_LIBCPP_CXX03_LANG)
   if constexpr (_Size == 0) {
     return 0;
   } else if constexpr (_Size <= __base::__bits_per_word) {

--- a/libcxx/src/atomic.cpp
+++ b/libcxx/src/atomic.cpp
@@ -21,17 +21,7 @@
 
 #ifdef __linux__
 
-#if defined(__ve__)
-// VE doesn't have linux/futex.h since futex system call is partially
-// implemented.
-#  define FUTEX_WAIT              0
-#  define FUTEX_WAKE              1
-#  define FUTEX_PRIVATE_FLAG      128
-#  define FUTEX_WAIT_PRIVATE      (FUTEX_WAIT | FUTEX_PRIVATE_FLAG)
-#  define FUTEX_WAKE_PRIVATE      (FUTEX_WAKE | FUTEX_PRIVATE_FLAG)
-#else
 #  include <linux/futex.h>
-#endif
 #  include <sys/syscall.h>
 #  include <unistd.h>
 


### PR DESCRIPTION
## Summary
- Enable `_BitInt` type support for VE target by adding `hasBitIntType()` override to `VE.h`
- Remove `__ve__` guard from `libcxx/include/bitset` (restored to upstream)
- Remove VE-specific `futex.h` workaround from `libcxx/src/atomic.cpp` (Docker build image updated to include `linux/futex.h` in VE sysroot)

## Changes
- `clang/lib/Basic/Targets/VE.h`: Added `hasBitIntType()` override
- `libcxx/include/bitset`: Removed `__ve__` guard
- `libcxx/src/atomic.cpp`: Removed VE futex.h workaround

## Test plan
- [x] check-llvm passed
- [x] check-clang passed
- [x] make build passed