### PR TITLE
[VE] Fix runtime test suite issues

### DIFF
--- a/clang/cmake/caches/VectorEngine.cmake
+++ b/clang/cmake/caches/VectorEngine.cmake
@@ -66,6 +66,10 @@ set(RUNTIMES_ve-unknown-linux-gnu_LIBCXXABI_USE_COMPILER_RT TRUE CACHE BOOL "")
 # VE uses Compiler-RT from libcxx.
 set(RUNTIMES_ve-unknown-linux-gnu_LIBCXX_USE_COMPILER_RT TRUE CACHE BOOL "")
 
+# Disable benchmarks for VE since Google Benchmark's try_run cannot execute
+# VE binaries on the host.
+set(RUNTIMES_ve-unknown-linux-gnu_LIBCXX_INCLUDE_BENCHMARKS OFF CACHE BOOL "")
+
 # Specify LIBDIR_SUFFIX for OpenMP to install them at following directories.
 #   install/lib/clang/${VERSION}/lib/x86_64-unknown-linux-gnu
 #   install/lib/clang/${VERSION}/lib/ve-unknown-linux-gnu

--- a/clang/lib/Basic/Targets/VE.h
+++ b/clang/lib/Basic/Targets/VE.h
@@ -42,7 +42,7 @@ public:
     MaxAtomicPromoteWidth = MaxAtomicInlineWidth = 64;
     HasUnalignedAccess = true;
 
-    WCharType = UnsignedInt;
+    WCharType = SignedInt;
     WIntType = UnsignedInt;
     UseZeroLengthBitfieldAlignment = true;
     resetDataLayout();

--- a/clang/test/Preprocessor/init-ve.c
+++ b/clang/test/Preprocessor/init-ve.c
@@ -267,9 +267,8 @@
 // VE:#define __UINT_LEAST8_TYPE__ unsigned char
 // VE:#define __USER_LABEL_PREFIX__
 // VE-NOT:#define __VECTOR__
-// VE:#define __WCHAR_MAX__ 4294967295U
-// VE:#define __WCHAR_TYPE__ unsigned int
-// VE:#define __WCHAR_UNSIGNED__ 1
+// VE:#define __WCHAR_MAX__ 2147483647
+// VE:#define __WCHAR_TYPE__ int
 // VE:#define __WCHAR_WIDTH__ 32
 // VE:#define __WINT_MAX__ 4294967295U
 // VE:#define __WINT_TYPE__ unsigned int

--- a/compiler-rt/lib/profile/InstrProfilingWriter.c
+++ b/compiler-rt/lib/profile/InstrProfilingWriter.c
@@ -311,8 +311,10 @@ COMPILER_RT_VISIBILITY int lprofWriteDataImpl(
   Header.Version = Version;
 
   /* On WIN64, label differences are truncated 32-bit values. Truncate
-   * CountersDelta to match. */
-#ifdef _WIN64
+   * CountersDelta to match.
+   * On VE, 8-byte pc-relative relocations are downgraded to R_VE_SREL32
+   * because R_VE_PC64 does not exist, so truncate here as well. */
+#if defined(_WIN64) || defined(__ve__)
   Header.CountersDelta = (uint32_t)Header.CountersDelta;
   Header.BitmapDelta = (uint32_t)Header.BitmapDelta;
 #endif

--- a/compiler-rt/test/builtins/Unit/dso_handle.cpp
+++ b/compiler-rt/test/builtins/Unit/dso_handle.cpp
@@ -6,7 +6,7 @@
 // RUN: %clangxx -g -o %t -fno-pic -no-pie -nostdlib %crt1 %crti %crtbegin %t.o %libstdcxx %libc -lm %libgcc %t.so %crtend %crtn
 // RUN: %run %t 2>&1 | FileCheck %s
 
-// UNSUPPORTED: target={{(arm|aarch64).*}}
+// UNSUPPORTED: target={{(arm|aarch64|ve).*}}
 
 #include <stdio.h>
 

--- a/compiler-rt/test/profile/Linux/lit.local.cfg.py
+++ b/compiler-rt/test/profile/Linux/lit.local.cfg.py
@@ -24,8 +24,9 @@ def is_gold_linker_available():
         return False
 
     # config.clang is not guaranteed to be just the executable!
+    target_cflags = getattr(config, "target_cflags", "")
     clang_cmd = subprocess.Popen(
-        " ".join([config.clang, "-fuse-ld=gold", "-xc", "-"]),
+        " ".join([config.clang, target_cflags, "-fuse-ld=gold", "-xc", "-"]),
         shell=True,
         universal_newlines=True,
         stdin=subprocess.PIPE,
@@ -34,10 +35,13 @@ def is_gold_linker_available():
     )
     clang_err = clang_cmd.communicate("int main() { return 0; }")[1]
 
-    if not "invalid linker" in clang_err:
-        return True
+    if "invalid linker" in clang_err:
+        return False
 
-    return False
+    if "unsupported ELF machine number" in clang_err:
+        return False
+
+    return True
 
 
 root = getRoot(config)

--- a/compiler-rt/test/profile/Posix/gcov-destructor.c
+++ b/compiler-rt/test/profile/Posix/gcov-destructor.c
@@ -1,5 +1,9 @@
 /// Test that destructors and destructors whose priorities are greater than 100 are tracked.
 // XFAIL: target={{.*haiku.*}}
+// VE linker (nld) does not sort .fini_array by INIT_PRIORITY, so
+// destructor(99) runs before __llvm_gcov_writeout (priority 100)
+// instead of after it.
+// XFAIL: target={{ve-.*}}
 // RUN: mkdir -p %t.dir && cd %t.dir
 // RUN: %clang --coverage %s -o %t -dumpdir ./
 // RUN: rm -f gcov-destructor.gcda && %run %t

--- a/compiler-rt/test/profile/instrprof-merge-entry-cover.c
+++ b/compiler-rt/test/profile/instrprof-merge-entry-cover.c
@@ -4,6 +4,10 @@
 
 // FIXME: llvm-profdata exits with "Malformed instrumentation profile data"
 // XFAIL: target={{.*windows.*}}
+// VE linker (nld) writes incorrect GOT entry for __stop___llvm_prf_names
+// (resolves to .dynamic address instead of section end), causing
+// __llvm_profile_get_size_for_buffer() to return ~67MB.
+// XFAIL: target={{ve-.*}}
 
 #include "profile_test.h"
 #include <stdint.h>

--- a/compiler-rt/test/profile/instrprof-merge-match.test
+++ b/compiler-rt/test/profile/instrprof-merge-match.test
@@ -5,3 +5,7 @@
 
 rpath isn't supported on Windows.
 UNSUPPORTED: target={{.*windows.*}}
+VE linker (nld) writes incorrect GOT entry for __stop___llvm_prf_names
+(resolves to .dynamic address instead of section end), causing profile
+merge to fail with incorrect buffer size.
+XFAIL: target={{ve-.*}}

--- a/compiler-rt/test/profile/instrprof-merge.c
+++ b/compiler-rt/test/profile/instrprof-merge.c
@@ -4,6 +4,10 @@
 
 // FIXME: llvm-profdata exits with "Malformed instrumentation profile data"
 // XFAIL: target={{.*windows.*}}
+// VE linker (nld) writes incorrect GOT entry for __stop___llvm_prf_names
+// (resolves to .dynamic address instead of section end), causing
+// __llvm_profile_get_size_for_buffer() to return ~67MB.
+// XFAIL: target={{ve-.*}}
 
 #include <stdint.h>
 #include <stdio.h>

--- a/compiler-rt/test/profile/instrprof-without-libc.c
+++ b/compiler-rt/test/profile/instrprof-without-libc.c
@@ -1,4 +1,8 @@
 // XFAIL: target={{.*}}-aix{{.*}}
+// VE linker (nld) writes incorrect GOT entry for __stop___llvm_prf_names
+// (resolves to .dynamic address instead of section end), causing
+// __llvm_profile_get_size_for_buffer() to return ~67MB.
+// XFAIL: target={{ve-.*}}
 // RUN: %clang_profgen -DCHECK_SYMBOLS -O3 -o %t.symbols %s
 // RUN: llvm-nm %t.symbols | FileCheck %s --check-prefix=CHECK-SYMBOLS
 // RUN: %clang_profgen -O3 -o %t %s

--- a/libcxxabi/test/guard_threaded_test.pass.cpp
+++ b/libcxxabi/test/guard_threaded_test.pass.cpp
@@ -9,6 +9,8 @@
 // UNSUPPORTED: c++03, c++11, c++14, c++17, c++20
 // UNSUPPORTED: no-threads
 // UNSUPPORTED: no-exceptions
+// VE supports a maximum of 64 threads per process, which is not enough for this test.
+// UNSUPPORTED: target=ve-{{.*}}
 
 #define TESTING_CXA_GUARD
 #include "../src/cxa_guard_impl.h"

--- a/libunwind/test/forceunwind.pass.cpp
+++ b/libunwind/test/forceunwind.pass.cpp
@@ -11,6 +11,9 @@
 // UNSUPPORTED: target={{.*-aix.*}}
 // UNSUPPORTED: target={{.*-windows.*}}
 
+// VE does not yet support the zero-cost unwinding APIs.
+// XFAIL: target=ve-{{.*}}
+
 // TODO: Figure out why this fails with Memory Sanitizer.
 // XFAIL: msan
 

--- a/libunwind/test/libunwind_01.pass.cpp
+++ b/libunwind/test/libunwind_01.pass.cpp
@@ -10,6 +10,9 @@
 // TODO: Investigate this failure on x86_64 macOS back deployment
 // XFAIL: stdlib=system && target=x86_64-apple-macosx{{10.9|10.10|10.11|10.12|10.13|10.14|10.15|11.0|12.0}}
 
+// VE does not yet support the zero-cost unwinding APIs.
+// XFAIL: target=ve-{{.*}}
+
 // TODO: Figure out why this fails with Memory Sanitizer.
 // XFAIL: msan
 

--- a/libunwind/test/libunwind_02.pass.cpp
+++ b/libunwind/test/libunwind_02.pass.cpp
@@ -7,6 +7,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// VE does not yet support the zero-cost unwinding APIs.
+// XFAIL: target=ve-{{.*}}
+
 // TODO: Figure out why this fails with Memory Sanitizer.
 // XFAIL: msan
 

--- a/libunwind/test/signal_frame.pass.cpp
+++ b/libunwind/test/signal_frame.pass.cpp
@@ -15,6 +15,9 @@
 // TODO: Figure out why this fails with Memory Sanitizer.
 // XFAIL: msan
 
+// VE does not yet support the zero-cost unwinding APIs.
+// XFAIL: target=ve-{{.*}}
+
 // UNSUPPORTED: libunwind-arm-ehabi
 
 // The AIX assembler does not support CFI directives, which

--- a/libunwind/test/unw_getcontext.pass.cpp
+++ b/libunwind/test/unw_getcontext.pass.cpp
@@ -7,6 +7,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// VE does not yet support the zero-cost unwinding APIs.
+// XFAIL: target=ve-{{.*}}
+
 #undef NDEBUG
 #include <assert.h>
 #include <libunwind.h>

--- a/libunwind/test/unw_resume.pass.cpp
+++ b/libunwind/test/unw_resume.pass.cpp
@@ -10,6 +10,9 @@
 // Ensure that unw_resume() resumes execution at the stack frame identified by
 // cursor.
 
+// VE does not yet support the zero-cost unwinding APIs.
+// XFAIL: target=ve-{{.*}}
+
 // TODO: Figure out why this fails with Memory Sanitizer.
 // XFAIL: msan
 

--- a/lld/ELF/Arch/VE.cpp
+++ b/lld/ELF/Arch/VE.cpp
@@ -54,8 +54,8 @@ VE::VE(Ctx &ctx) : TargetInfo(ctx) {
   pltEntrySize = 64;
   pltHeaderSize = 64;
 
-  // The .got has no preserved entries.
-  // gotHeaderEntriesNum = 0;
+  // The .got has one preserved entry for _DYNAMIC.
+  gotHeaderEntriesNum = 1;
 
   // _GLOBAL_OFFSET_TABLE_ == .got.plt.
   gotBaseSymInGotPlt = true;

--- a/llvm/lib/Target/VE/MCTargetDesc/VEAsmBackend.cpp
+++ b/llvm/lib/Target/VE/MCTargetDesc/VEAsmBackend.cpp
@@ -8,6 +8,7 @@
 
 #include "MCTargetDesc/VEFixupKinds.h"
 #include "MCTargetDesc/VEMCTargetDesc.h"
+#include "llvm/ADT/StringSwitch.h"
 #include "llvm/MC/MCAsmBackend.h"
 #include "llvm/MC/MCELFObjectWriter.h"
 #include "llvm/MC/MCExpr.h"
@@ -89,6 +90,20 @@ protected:
 public:
   VEAsmBackend(const Target &T)
       : MCAsmBackend(llvm::endianness::little), TheTarget(T) {}
+
+  std::optional<MCFixupKind> getFixupKind(StringRef Name) const override {
+    unsigned Type = llvm::StringSwitch<unsigned>(Name)
+#define ELF_RELOC(X, Y) .Case(#X, Y)
+#include "llvm/BinaryFormat/ELFRelocs/VE.def"
+#undef ELF_RELOC
+                      .Case("BFD_RELOC_NONE", ELF::R_VE_NONE)
+                      .Case("BFD_RELOC_32", ELF::R_VE_REFLONG)
+                      .Case("BFD_RELOC_64", ELF::R_VE_REFQUAD)
+                      .Default(-1u);
+    if (Type == -1u)
+      return std::nullopt;
+    return static_cast<MCFixupKind>(FirstLiteralRelocationKind + Type);
+  }
 
   MCFixupKindInfo getFixupKindInfo(MCFixupKind Kind) const override {
     const static MCFixupKindInfo Infos[VE::NumTargetFixupKinds] = {


### PR DESCRIPTION
## Summary
- Fix gold linker availability check for cross-compilation targets
- Mark known-failing tests as XFAIL/UNSUPPORTED on VE (compiler-rt profile, libunwind, libcxxabi)
- Fix lld VE GOT header entry count
- Add VEAsmBackend getFixupKind override
- Truncate CountersDelta/BitmapDelta to 32 bits on VE
- Fix wchar_t to be signed int, matching ncc and gcc-ve
- Disable libcxx benchmarks in VectorEngine.cmake

## Test plan
- [x] check-llvm passes
- [x] zzruntest passes
- [x] check-compiler-rt passes (with expected XFAILs)
- [x] check-libunwind passes (with expected XFAILs)
- [x] check-libcxx improvement (226 → 157 failures)