### PR TITLE
[lld][VE] Place .tbss in RW segment for VE dynamic linker compatibility

### DIFF
--- a/lld/ELF/Writer.cpp
+++ b/lld/ELF/Writer.cpp
@@ -800,6 +800,14 @@ unsigned elf::getSectionRank(Ctx &ctx, OutputSection &osec) {
       rank |= 1;
   }
 
+  if (ctx.arg.emachine == EM_VE) {
+    // VE's dynamic linker requires TLS sections to be within a PT_LOAD
+    // segment. Place .tbss in the RW area (after .data) instead of before
+    // the page boundary.
+    if ((osec.flags & SHF_TLS) && osec.type == SHT_NOBITS)
+      rank |= RF_NOT_TLS;
+  }
+
   return rank;
 }
 


### PR DESCRIPTION
## Summary
- VE's dynamic linker rejects shared libraries where .tbss is placed in the gap between R+E and RW LOAD segments ("Failed to validate the gap between text/data")
- Fix getSectionRank() to sort .tbss into the RW area for VE targets
- Resolves 14 check-compiler-rt failures caused by TLS segment placement

## Test plan
- [x] check-compiler-rt: FAIL 1 (pre-existing LTO issue only), TLS-related 14 failures all resolved
- [x] Internal regression tests: 0 errors, no performance regression