### PR TITLE
[lld][VE] Add VE target triple to LTO e_machine mapping

### DIFF
--- a/lld/ELF/InputFiles.cpp
+++ b/lld/ELF/InputFiles.cpp
@@ -1787,6 +1787,8 @@ static uint16_t getBitcodeMachineKind(Ctx &ctx, StringRef path,
     return EM_SPARCV9;
   case Triple::systemz:
     return EM_S390;
+  case Triple::ve:
+    return EM_VE;
   case Triple::x86:
     return t.isOSIAMCU() ? EM_IAMCU : EM_386;
   case Triple::x86_64:


### PR DESCRIPTION
## Summary
- Add the missing `Triple::ve -> EM_VE` case in `getBitcodeMachineKind()` so that LTO works for the VE target
- Without this, lld fails with "could not infer e_machine from bitcode target triple ve-unknown-linux-gnu" when linking LTO bitcode

## Test plan
- [x] check-compiler-rt: 237 passed, 0 failures (instrprof-gc-sections.c now passes with LTO)
- [x] Internal regression tests: 0 errors, no performance regression