### PR TITLE
[VE] Save/restore s15/s16 in SjLj EH functions to fix child thread crash

### DIFF
--- a/llvm/lib/Target/VE/VEFrameLowering.cpp
+++ b/llvm/lib/Target/VE/VEFrameLowering.cpp
@@ -163,7 +163,7 @@ void VEFrameLowering::emitPrologueInsns(MachineFunction &MF,
         .addImm(8)
         .addReg(VE::SX10);
   }
-  if (hasGOT(MF)) {
+  if (hasGOT(MF) || MF.getFrameInfo().hasFunctionContextIndex()) {
     BuildMI(MBB, MBBI, DL, TII.get(VE::STrii))
         .addReg(VE::SX11)
         .addImm(0)
@@ -204,7 +204,7 @@ void VEFrameLowering::emitEpilogueInsns(MachineFunction &MF,
         .addReg(VE::SX11)
         .addImm(0)
         .addImm(40);
-  if (hasGOT(MF)) {
+  if (hasGOT(MF) || MF.getFrameInfo().hasFunctionContextIndex()) {
     BuildMI(MBB, MBBI, DL, TII.get(VE::LDrii), VE::SX16)
         .addReg(VE::SX11)
         .addImm(0)

--- a/llvm/test/CodeGen/VE/Scalar/builtin_sjlj_callsite.ll
+++ b/llvm/test/CodeGen/VE/Scalar/builtin_sjlj_callsite.ll
@@ -9,6 +9,8 @@ define void @test_callsite() personality ptr @__gxx_personality_sj0 {
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    st %s9, (, %s11)
 ; CHECK-NEXT:    st %s10, 8(, %s11)
+; CHECK-NEXT:    st %s15, 24(, %s11)
+; CHECK-NEXT:    st %s16, 32(, %s11)
 ; CHECK-NEXT:    or %s9, 0, %s11
 ; CHECK-NEXT:    lea %s11, -432(, %s11)
 ; CHECK-NEXT:    brge.l %s11, %s8, .LBB0_7
@@ -59,12 +61,12 @@ define void @test_callsite() personality ptr @__gxx_personality_sj0 {
 ; CHECK-NEXT:    bsic %s10, (, %s12)
 ; CHECK-NEXT:    or %s0, 1, (0)1
 ; CHECK-NEXT:    st %s0, -96(, %s9)
-; CHECK-NEXT:  .Ltmp0:
+; CHECK-NEXT:  .Ltmp0: # EH_LABEL
 ; CHECK-NEXT:    lea %s0, f@lo
 ; CHECK-NEXT:    and %s0, %s0, (32)0
 ; CHECK-NEXT:    lea.sl %s12, f@hi(, %s0)
 ; CHECK-NEXT:    bsic %s10, (, %s12)
-; CHECK-NEXT:  .Ltmp1:
+; CHECK-NEXT:  .Ltmp1: # EH_LABEL
 ; CHECK-NEXT:  .LBB0_2: # %try.cont
 ; CHECK-NEXT:    or %s0, -1, (0)1
 ; CHECK-NEXT:    st %s0, -96(, %s9)
@@ -94,6 +96,8 @@ define void @test_callsite() personality ptr @__gxx_personality_sj0 {
 ; CHECK-NEXT:    ld %s19, 56(, %s9) # 8-byte Folded Reload
 ; CHECK-NEXT:    ld %s18, 48(, %s9) # 8-byte Folded Reload
 ; CHECK-NEXT:    or %s11, 0, %s9
+; CHECK-NEXT:    ld %s16, 32(, %s11)
+; CHECK-NEXT:    ld %s15, 24(, %s11)
 ; CHECK-NEXT:    ld %s10, 8(, %s11)
 ; CHECK-NEXT:    ld %s9, (, %s11)
 ; CHECK-NEXT:    b.l.t (, %s10)
@@ -113,7 +117,7 @@ define void @test_callsite() personality ptr @__gxx_personality_sj0 {
 ; CHECK-NEXT:    ld %s0, (%s0, %s1)
 ; CHECK-NEXT:    b.l.t (, %s0)
 ; CHECK-NEXT:  .LBB0_1: # %lpad
-; CHECK-NEXT:  .Ltmp2:
+; CHECK-NEXT:  .Ltmp2: # EH_LABEL
 ; CHECK-NEXT:    ld %s0, -88(, %s9)
 ; CHECK-NEXT:    ld %s0, -80(, %s9)
 ; CHECK-NEXT:    br.l.t .LBB0_2
@@ -180,13 +184,13 @@ define void @test_callsite() personality ptr @__gxx_personality_sj0 {
 ; PIC-NEXT:    bsic %s10, (, %s12)
 ; PIC-NEXT:    or %s0, 1, (0)1
 ; PIC-NEXT:    st %s0, -96(, %s9)
-; PIC-NEXT:  .Ltmp0:
+; PIC-NEXT:  .Ltmp0: # EH_LABEL
 ; PIC-NEXT:    lea %s12, f@plt_lo(-24)
 ; PIC-NEXT:    and %s12, %s12, (32)0
 ; PIC-NEXT:    sic %s16
 ; PIC-NEXT:    lea.sl %s12, f@plt_hi(%s16, %s12)
 ; PIC-NEXT:    bsic %s10, (, %s12)
-; PIC-NEXT:  .Ltmp1:
+; PIC-NEXT:  .Ltmp1: # EH_LABEL
 ; PIC-NEXT:  .LBB0_2: # %try.cont
 ; PIC-NEXT:    or %s0, -1, (0)1
 ; PIC-NEXT:    st %s0, -96(, %s9)
@@ -248,7 +252,7 @@ define void @test_callsite() personality ptr @__gxx_personality_sj0 {
 ; PIC-NEXT:    adds.l %s0, %s0, %s1
 ; PIC-NEXT:    b.l.t (, %s0)
 ; PIC-NEXT:  .LBB0_1: # %lpad
-; PIC-NEXT:  .Ltmp2:
+; PIC-NEXT:  .Ltmp2: # EH_LABEL
 ; PIC-NEXT:    ld %s0, -88(, %s9)
 ; PIC-NEXT:    ld %s0, -80(, %s9)
 ; PIC-NEXT:    br.l.t .LBB0_2

--- a/llvm/test/CodeGen/VE/Scalar/builtin_sjlj_landingpad.ll
+++ b/llvm/test/CodeGen/VE/Scalar/builtin_sjlj_landingpad.ll
@@ -10,6 +10,8 @@ define dso_local i32 @foo(i32 %arg) local_unnamed_addr personality ptr @__gxx_pe
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    st %s9, (, %s11)
 ; CHECK-NEXT:    st %s10, 8(, %s11)
+; CHECK-NEXT:    st %s15, 24(, %s11)
+; CHECK-NEXT:    st %s16, 32(, %s11)
 ; CHECK-NEXT:    or %s9, 0, %s11
 ; CHECK-NEXT:    lea %s11, -352(, %s11)
 ; CHECK-NEXT:    brge.l %s11, %s8, .LBB0_8
@@ -60,12 +62,12 @@ define dso_local i32 @foo(i32 %arg) local_unnamed_addr personality ptr @__gxx_pe
 ; CHECK-NEXT:    bsic %s10, (, %s12)
 ; CHECK-NEXT:    or %s0, 1, (0)1
 ; CHECK-NEXT:    st %s0, -96(, %s9)
-; CHECK-NEXT:  .Ltmp0:
+; CHECK-NEXT:  .Ltmp0: # EH_LABEL
 ; CHECK-NEXT:    lea %s0, errorbar@lo
 ; CHECK-NEXT:    and %s0, %s0, (32)0
 ; CHECK-NEXT:    lea.sl %s12, errorbar@hi(, %s0)
 ; CHECK-NEXT:    bsic %s10, (, %s12)
-; CHECK-NEXT:  .Ltmp1:
+; CHECK-NEXT:  .Ltmp1: # EH_LABEL
 ; CHECK-NEXT:  # %bb.1: # %exit
 ; CHECK-NEXT:    lea %s0, _Unwind_SjLj_Unregister@lo
 ; CHECK-NEXT:    and %s0, %s0, (32)0
@@ -91,6 +93,8 @@ define dso_local i32 @foo(i32 %arg) local_unnamed_addr personality ptr @__gxx_pe
 ; CHECK-NEXT:    ld %s19, 56(, %s9) # 8-byte Folded Reload
 ; CHECK-NEXT:    ld %s18, 48(, %s9) # 8-byte Folded Reload
 ; CHECK-NEXT:    or %s11, 0, %s9
+; CHECK-NEXT:    ld %s16, 32(, %s11)
+; CHECK-NEXT:    ld %s15, 24(, %s11)
 ; CHECK-NEXT:    ld %s10, 8(, %s11)
 ; CHECK-NEXT:    ld %s9, (, %s11)
 ; CHECK-NEXT:    b.l.t (, %s10)
@@ -110,7 +114,7 @@ define dso_local i32 @foo(i32 %arg) local_unnamed_addr personality ptr @__gxx_pe
 ; CHECK-NEXT:    ld %s0, (%s0, %s1)
 ; CHECK-NEXT:    b.l.t (, %s0)
 ; CHECK-NEXT:  .LBB0_6: # %handle
-; CHECK-NEXT:  .Ltmp2:
+; CHECK-NEXT:  .Ltmp2: # EH_LABEL
 ; CHECK-NEXT:    ld %s0, -88(, %s9)
 ; CHECK-NEXT:    ld %s0, -80(, %s9)
 ; CHECK-NEXT:    lea %s0, _Unwind_SjLj_Unregister@lo
@@ -183,13 +187,13 @@ define dso_local i32 @foo(i32 %arg) local_unnamed_addr personality ptr @__gxx_pe
 ; PIC-NEXT:    bsic %s10, (, %s12)
 ; PIC-NEXT:    or %s0, 1, (0)1
 ; PIC-NEXT:    st %s0, -96(, %s9)
-; PIC-NEXT:  .Ltmp0:
+; PIC-NEXT:  .Ltmp0: # EH_LABEL
 ; PIC-NEXT:    lea %s12, errorbar@plt_lo(-24)
 ; PIC-NEXT:    and %s12, %s12, (32)0
 ; PIC-NEXT:    sic %s16
 ; PIC-NEXT:    lea.sl %s12, errorbar@plt_hi(%s16, %s12)
 ; PIC-NEXT:    bsic %s10, (, %s12)
-; PIC-NEXT:  .Ltmp1:
+; PIC-NEXT:  .Ltmp1: # EH_LABEL
 ; PIC-NEXT:  # %bb.1: # %exit
 ; PIC-NEXT:    lea %s12, _Unwind_SjLj_Unregister@plt_lo(-24)
 ; PIC-NEXT:    and %s12, %s12, (32)0
@@ -247,7 +251,7 @@ define dso_local i32 @foo(i32 %arg) local_unnamed_addr personality ptr @__gxx_pe
 ; PIC-NEXT:    adds.l %s0, %s0, %s1
 ; PIC-NEXT:    b.l.t (, %s0)
 ; PIC-NEXT:  .LBB0_6: # %handle
-; PIC-NEXT:  .Ltmp2:
+; PIC-NEXT:  .Ltmp2: # EH_LABEL
 ; PIC-NEXT:    ld %s0, -88(, %s9)
 ; PIC-NEXT:    ld %s0, -80(, %s9)
 ; PIC-NEXT:    lea %s12, _Unwind_SjLj_Unregister@plt_lo(-24)


### PR DESCRIPTION
## Summary
- Fix SIGBUS crash when using SjLj exception handling (throw/catch) in child threads created via pthread_create
- SjLj longjmp skips epilogues of intermediate PIC functions (libunwind, libc++abi), leaving s15(GOT)/s16(PLT) corrupted with those libraries' GOT/PLT base values
- Extend s15/s16 save/restore condition in prologue/epilogue to also cover SjLj EH functions (`hasGOT(MF) || hasFunctionContextIndex()`)

## Root Cause
1. SjLj longjmp restores only FP/SP/IC and skips intermediate function epilogues
2. Intermediate PIC functions (libunwind, libc++abi) set s15/s16 to their own GOT/PLT base
3. After longjmp, s15/s16 remain corrupted with libunwind's GOT base values
4. Non-PIC functions had `hasGOT==false`, so their prologue/epilogue did not save/restore s15/s16
5. On thread exit, glibc's `start_thread` references s15 and triggers SIGBUS

## Test plan
- [x] check-clang: all PASS
- [x] check-llvm: all PASS (test patterns updated)
- [x] Internal regression tests: all PASS
- [x] Manual tests: throw/catch in pthread child threads (-O0, -O2, std::thread)