### PR TITLE
[VE] Use monc.hdb as trap instruction

### DIFF
--- a/libcxx/test/libcxx/assertions/modes/override_with_extensive_mode.pass.cpp
+++ b/libcxx/test/libcxx/assertions/modes/override_with_extensive_mode.pass.cpp
@@ -15,8 +15,7 @@
 // debug mode).
 // XFAIL: libcpp-hardening-mode=debug && availability-verbose_abort-missing
 // HWASAN replaces TRAP with abort or error exit code.
-// VE lacks a hardware trap instruction; __builtin_trap lowers to abort.
-// XFAIL: hwasan || target=ve{{.*}}
+// XFAIL: hwasan
 // ADDITIONAL_COMPILE_FLAGS: -U_LIBCPP_HARDENING_MODE -D_LIBCPP_HARDENING_MODE=_LIBCPP_HARDENING_MODE_EXTENSIVE
 
 #include <cassert>

--- a/libcxx/test/libcxx/assertions/modes/override_with_fast_mode.pass.cpp
+++ b/libcxx/test/libcxx/assertions/modes/override_with_fast_mode.pass.cpp
@@ -15,8 +15,7 @@
 // debug mode).
 // XFAIL: libcpp-hardening-mode=debug && availability-verbose_abort-missing
 // HWASAN replaces TRAP with abort or error exit code.
-// VE lacks a hardware trap instruction; __builtin_trap lowers to abort.
-// XFAIL: hwasan || target=ve{{.*}}
+// XFAIL: hwasan
 // ADDITIONAL_COMPILE_FLAGS: -U_LIBCPP_HARDENING_MODE -D_LIBCPP_HARDENING_MODE=_LIBCPP_HARDENING_MODE_FAST
 
 #include <cassert>

--- a/llvm/lib/Target/VE/VEISelLowering.cpp
+++ b/llvm/lib/Target/VE/VEISelLowering.cpp
@@ -347,12 +347,9 @@ void VETargetLowering::initSPUActions() {
   // Other configurations related to f128.
   setOperationAction(ISD::BR_CC, MVT::f128, Legal);
 
-  // TRAP to expand (which turns it into abort).
-  setOperationAction(ISD::TRAP, MVT::Other, Expand);
-
-  // On most systems, DEBUGTRAP and TRAP have no difference. The "Expand"
-  // here is to inform DAG Legalizer to replace DEBUGTRAP with TRAP.
-  setOperationAction(ISD::DEBUGTRAP, MVT::Other, Expand);
+  // Use monc.hdb as a trap instruction, which generates SIGTRAP.
+  setOperationAction(ISD::TRAP, MVT::Other, Legal);
+  setOperationAction(ISD::DEBUGTRAP, MVT::Other, Legal);
 }
 
 static bool isLegalVectorVT(EVT VT) {

--- a/llvm/lib/Target/VE/VEInstrInfo.td
+++ b/llvm/lib/Target/VE/VEInstrInfo.td
@@ -1734,6 +1734,9 @@ let sx = 0, cy = 0, sy = 0, cz = 0, sz = 0, hasSideEffects = 1 in {
   let cx = 1, isTrap = 1 in def MONCHDB : RR<0x3F, (outs), (ins), "monc.hdb">;
 }
 
+def : Pat<(trap), (MONCHDB)>;
+def : Pat<(debugtrap), (MONCHDB)>;
+
 // Section 8.19.9 - LCR (Load Communication Register)
 defm LCR : LOADCRm<"lcr", 0x40, I64>;
 


### PR DESCRIPTION
## Summary
- Map `ISD::TRAP` and `ISD::DEBUGTRAP` to the `MONCHDB` instruction (`monc.hdb`), which generates SIGTRAP on VE hardware
- Previously these were expanded to `abort()` calls generating SIGABRT instead of SIGTRAP
- Remove VE XFAIL from two libc++ assertion mode tests that were failing due to the abort-based trap behavior

## Test plan
- [x] check-llvm: 37,436 passed, 0 failures
- [x] VE CodeGen tests: 464 passed, 0 failures
- [x] VE real hardware: `__builtin_trap()` correctly generates SIGTRAP
- [x] check-libcxx: 10,129 passed, 0 trap-related failures (XFAIL removal confirmed working)