### PR TITLE
[VE] Fix SjLj s15 handling and PIC jump table encoding

### DIFF
--- a/lld/ELF/Writer.cpp
+++ b/lld/ELF/Writer.cpp
@@ -801,6 +801,16 @@ unsigned elf::getSectionRank(Ctx &ctx, OutputSection &osec) {
   }
 
   if (ctx.arg.emachine == EM_VE) {
+    // VEOS calculates AT_PHDR from the entry point's page base address,
+    // so the entry point must reside in the first page.  Place executable
+    // sections (.text) before read-only data (.rodata) to keep .text near
+    // the start of the R E segment and prevent a large .rodata from
+    // pushing the entry point past the 2 MB page boundary.
+    if (rank & RF_EXEC)
+      rank = (rank & ~RF_EXEC) | RF_RODATA;
+    else if (rank & RF_RODATA)
+      rank = (rank & ~RF_RODATA) | RF_EXEC;
+
     // VE's dynamic linker requires TLS sections to be within a PT_LOAD
     // segment. Place .tbss in the RW area (after .data) instead of before
     // the page boundary.

--- a/lld/test/ELF/basic-ve.s
+++ b/lld/test/ELF/basic-ve.s
@@ -25,12 +25,12 @@ _start:
 # CHECK-NEXT:   Version: 1
 # CHECK-NEXT:   Entry: [[ENTRY:0x600[0-9A-F]+]]
 # CHECK-NEXT:   ProgramHeaderOffset: 0x40
-# CHECK-NEXT:   SectionHeaderOffset: 0x1A0
+# CHECK-NEXT:   SectionHeaderOffset: 0x168
 # CHECK-NEXT:   Flags [ (0x0)
 # CHECK-NEXT:   ]
 # CHECK-NEXT:   HeaderSize: 64
 # CHECK-NEXT:   ProgramHeaderEntrySize: 56
-# CHECK-NEXT:   ProgramHeaderCount: 4
+# CHECK-NEXT:   ProgramHeaderCount: 3
 # CHECK-NEXT:   SectionHeaderEntrySize: 64
 # CHECK-NEXT:   SectionHeaderCount: 6
 # CHECK-NEXT:   StringTableSectionIndex: 4
@@ -59,7 +59,7 @@ _start:
 # CHECK-NEXT:       SHF_EXECINSTR (0x4)
 # CHECK-NEXT:     ]
 # CHECK-NEXT:     Address: [[ENTRY]]
-# CHECK-NEXT:     Offset: 0x120
+# CHECK-NEXT:     Offset: 0xE8
 # CHECK-NEXT:     Size: 16
 # CHECK-NEXT:     Link: 0
 # CHECK-NEXT:     Info: 0
@@ -75,7 +75,7 @@ _start:
 # CHECK-NEXT:       SHF_STRINGS (0x20)
 # CHECK-NEXT:     ]
 # CHECK-NEXT:     Address: 0x0
-# CHECK-NEXT:     Offset: 0x130
+# CHECK-NEXT:     Offset: 0xF8
 # CHECK-NEXT:     Size: 8
 # CHECK-NEXT:     Link: 0
 # CHECK-NEXT:     Info: 0
@@ -89,7 +89,7 @@ _start:
 # CHECK-NEXT:     Flags [ (0x0)
 # CHECK-NEXT:     ]
 # CHECK-NEXT:     Address: 0x0
-# CHECK-NEXT:     Offset: 0x138
+# CHECK-NEXT:     Offset: 0x100
 # CHECK-NEXT:     Size: 48
 # CHECK-NEXT:     Link: 5
 # CHECK-NEXT:     Info: 1
@@ -103,7 +103,7 @@ _start:
 # CHECK-NEXT:     Flags [ (0x0)
 # CHECK-NEXT:     ]
 # CHECK-NEXT:     Address: 0x0
-# CHECK-NEXT:     Offset: 0x168
+# CHECK-NEXT:     Offset: 0x130
 # CHECK-NEXT:     Size: 42
 # CHECK-NEXT:     Link: 0
 # CHECK-NEXT:     Info: 0
@@ -117,7 +117,7 @@ _start:
 # CHECK-NEXT:     Flags [ (0x0)
 # CHECK-NEXT:     ]
 # CHECK-NEXT:     Address: 0x0
-# CHECK-NEXT:     Offset: 0x192
+# CHECK-NEXT:     Offset: 0x15A
 # CHECK-NEXT:     Size: 8
 # CHECK-NEXT:     Link: 0
 # CHECK-NEXT:     Info: 0
@@ -131,8 +131,8 @@ _start:
 # CHECK-NEXT:     Offset: 0x40
 # CHECK-NEXT:     VirtualAddress: 0x600000000040
 # CHECK-NEXT:     PhysicalAddress: 0x600000000040
-# CHECK-NEXT:     FileSize: 224
-# CHECK-NEXT:     MemSize: 224
+# CHECK-NEXT:     FileSize: 168
+# CHECK-NEXT:     MemSize: 168
 # CHECK-NEXT:     Flags [ (0x4)
 # CHECK-NEXT:       PF_R (0x4)
 # CHECK-NEXT:     ]
@@ -143,25 +143,13 @@ _start:
 # CHECK-NEXT:     Offset: 0x0
 # CHECK-NEXT:     VirtualAddress: 0x600000000000
 # CHECK-NEXT:     PhysicalAddress: 0x600000000000
-# CHECK-NEXT:     FileSize: 288
-# CHECK-NEXT:     MemSize: 288
-# CHECK-NEXT:     Flags [ (0x4)
-# CHECK-NEXT:       PF_R (0x4)
-# CHECK-NEXT:     ]
-# CHECK-NEXT:     Alignment: 1048576
-# CHECK-NEXT:   }
-# CHECK-NEXT:   ProgramHeader {
-# CHECK-NEXT:     Type: PT_LOAD (0x1)
-# CHECK-NEXT:     Offset: 0x120
-# CHECK-NEXT:     VirtualAddress: 0x600000100120
-# CHECK-NEXT:     PhysicalAddress: 0x600000100120
-# CHECK-NEXT:     FileSize: 16
-# CHECK-NEXT:     MemSize: 16
+# CHECK-NEXT:     FileSize: 248
+# CHECK-NEXT:     MemSize: 248
 # CHECK-NEXT:     Flags [ (0x5)
 # CHECK-NEXT:       PF_R (0x4)
 # CHECK-NEXT:       PF_X (0x1)
 # CHECK-NEXT:     ]
-# CHECK-NEXT:     Alignment: 1048576
+# CHECK-NEXT:     Alignment: 2097152
 # CHECK-NEXT:   }
 # CHECK-NEXT:   ProgramHeader {
 # CHECK-NEXT:     Type: PT_GNU_STACK

--- a/lld/test/ELF/emulation-ve.s
+++ b/lld/test/ELF/emulation-ve.s
@@ -22,7 +22,7 @@
 # CHECK-NEXT:   Version: 1
 # CHECK-NEXT:   Entry:
 # CHECK-NEXT:   ProgramHeaderOffset: 0x40
-# CHECK-NEXT:   SectionHeaderOffset: 0x190
+# CHECK-NEXT:   SectionHeaderOffset: 0x158
 # CHECK-NEXT:   Flags [ (0x0)
 # CHECK-NEXT:   ]
 

--- a/lld/test/ELF/ve-plt.s
+++ b/lld/test/ELF/ve-plt.s
@@ -11,68 +11,68 @@
 # RUN: llvm-readelf -x .got.plt %t.exe | FileCheck --check-prefix=GOTPLT %s
 # RUN: llvm-objdump -d --no-show-raw-insn %t.exe | FileCheck --check-prefixes=DIS %s
 
-# SEC: .plt PROGBITS 0000600000000330
+# SEC: .plt PROGBITS 00006000000002c0
 
 ## A canonical PLT has a non-zero st_value.
 # NM: Symbol table '.dynsym' contains
 # NM: 0000000000000000 0 FUNC WEAK   DEFAULT UND weak
-# NM: 0000600000000370 0 FUNC GLOBAL DEFAULT UND bar
+# NM: 0000600000000300 0 FUNC GLOBAL DEFAULT UND bar
 # NM: Symbol table '.symtab' contains
-# NM: 0000600000000320     0 NOTYPE  GLOBAL DEFAULT     6 foo
-# NM: 0000600000000370     0 FUNC    GLOBAL DEFAULT   UND bar
+# NM: 00006000000002b0     0 NOTYPE  GLOBAL DEFAULT     6 foo
+# NM: 0000600000000300     0 FUNC    GLOBAL DEFAULT   UND bar
 # NM: 0000000000000000     0 FUNC    WEAK   DEFAULT   UND weak
 
 ## The .got.plt slots relocated by .rela.plt point to .plt
 ## This is required by glibc.
 # RELOC:      .rela.plt {
-# RELOC-NEXT:   0x6000004000E8 R_VE_JUMP_SLOT bar 0x0
-# RELOC-NEXT:   0x6000004000F0 R_VE_JUMP_SLOT weak 0x0
+# RELOC-NEXT:   0x6000002000E8 R_VE_JUMP_SLOT bar 0x0
+# RELOC-NEXT:   0x6000002000F0 R_VE_JUMP_SLOT weak 0x0
 # RELOC-NEXT: }
 # GOTPLT:      section '.got.plt'
-# GOTPLT-NEXT: 0x6000004000d0 00002000 00600000 00000000 00000000
-# GOTPLT-NEXT: 0x6000004000e0 00000000 00000000 98030000 00600000
-# GOTPLT-NEXT: 0x6000004000f0 d8030000 00600000
+# GOTPLT-NEXT: 0x6000002000d0 00002000 00600000 00000000 00000000
+# GOTPLT-NEXT: 0x6000002000e0 00000000 00000000 28030000 00600000
+# GOTPLT-NEXT: 0x6000002000f0 68030000 00600000
 
 # DIS:      <_start>:
 ## Direct call
-## foo = 0x0000600000000320 = (24576 << 32) | 800
-# DIS-NEXT:   600000000290: lea %s12, 800
+## foo = 0x00006000000002b0 = (24576 << 32) | 688
+# DIS-NEXT:   600000000220: lea %s12, 688
 # DIS-NEXT:                 and %s12, %s12, (32)0
 # DIS-NEXT:                 lea.sl %s12, 24576(, %s12)
 # DIS-NEXT:                 bsic %s10, (%s12)
-## bar = 0x0000600000000370 = (24576 << 32) | 880
-# DIS-NEXT:   6000000002b0: lea %s12, 880
+## bar = 0x0000600000000300 = (24576 << 32) | 768
+# DIS-NEXT:   600000000240: lea %s12, 768
 # DIS-NEXT:                 and %s12, %s12, (32)0
 # DIS-NEXT:                 lea.sl %s12, 24576(, %s12)
 # DIS-NEXT:                 bsic %s10, (%s12)
-## bar@plt - . = 0x0000600000000370 - 0x00006000000002d0
+## bar@plt - . = 0x0000600000000300 - 0x0000600000000260
 ##             = 0x00000000000000a0 = 160
-# DIS-NEXT:   6000000002d0: lea %s12, 160(-24)
+# DIS-NEXT:   600000000260: lea %s12, 160(-24)
 # DIS-NEXT:                 and %s12, %s12, (32)0
 # DIS-NEXT:                 sic %s60
 # DIS-NEXT:                 lea.sl %s12, (%s12, %s60)
 # DIS-NEXT:                 bsic %s10, (%s12)
-## weak@plt - . = 0x00006000000003b0 - 0x00006000000002f8
+## weak@plt - . = 0x0000600000000340 - 0x0000600000000288
 ##              = 0x00000000000000b8 = 184
-# DIS-NEXT:   6000000002f8: lea %s12, 184(-24)
+# DIS-NEXT:   600000000288: lea %s12, 184(-24)
 # DIS-NEXT:                 and %s12, %s12, (32)0
 # DIS-NEXT:                 sic %s60
 # DIS-NEXT:                 lea.sl %s12, (%s12, %s60)
 # DIS-NEXT:                 bsic %s10, (%s12)
 # DIS:      <foo>:
-# DIS-NEXT:   600000000320: b.l (, %s10)
+# DIS-NEXT:   6000000002b0: b.l (, %s10)
 
 # DIS:      Disassembly of section .plt:
 # DIS:      <.plt>:
-## &.got.plt = 0x6000004000d0 = (24576 << 32) | 4194512
-# DIS-NEXT:   600000000330: lea %s62, 4194512
+## &.got.plt = 0x6000002000d0 = (24576 << 32) | 2097360
+# DIS-NEXT:   6000000002c0: lea %s62, 2097360
 # DIS-NEXT:                 and %s62, %s62, (32)0
 # DIS-NEXT:                 lea.sl %s62, 24576(, %s62)
 # DIS-NEXT:                 ld %s63, 8(, %s62)
 # DIS-NEXT:                 b.l.t (, %s63)
 
-## &.got.plt[bar] = 0x6000004000e8 = (24576 << 32) | 4194536
-# DIS:        600000000370: lea %s13, 4194536
+## &.got.plt[bar] = 0x6000002000e8 = (24576 << 32) | 2097384
+# DIS:        600000000300: lea %s13, 2097384
 # DIS-NEXT:                 and %s13, %s13, (32)0
 # DIS-NEXT:                 lea.sl %s13, 24576(, %s13)
 # DIS-NEXT:                 ld %s12, (, %s13)
@@ -80,8 +80,8 @@
 # DIS-NEXT:                 lea %s13, 0
 # DIS-NEXT:                 br.l.t -112
 
-## &.got.plt[weak] = 0x6000004000f0 = (24576 << 32) | 4194544
-# DIS:        6000000003b0: lea %s13, 4194544
+## &.got.plt[weak] = 0x6000002000f0 = (24576 << 32) | 2097392
+# DIS:        600000000340: lea %s13, 2097392
 # DIS-NEXT:                 and %s13, %s13, (32)0
 # DIS-NEXT:                 lea.sl %s13, 24576(, %s13)
 # DIS-NEXT:                 ld %s12, (, %s13)

--- a/lld/test/ELF/ve-reloc-copy.s
+++ b/lld/test/ELF/ve-reloc-copy.s
@@ -8,9 +8,9 @@
 # RUN: llvm-nm -S %t | FileCheck --check-prefix=NM %s
 
 # REL:        .rela.dyn {
-# REL-NEXT:   0x600000400320 R_VE_COPY x 0x0
+# REL-NEXT:   0x6000002002B0 R_VE_COPY x 0x0
 # REL-NEXT:   }
 
-# NM: 0000600000400320 0000000000000004 B x
+# NM: 00006000002002b0 0000000000000004 B x
 
 lea %s0, x

--- a/lld/test/ELF/ve-reloc-got.s
+++ b/lld/test/ELF/ve-reloc-got.s
@@ -5,11 +5,11 @@
 # RUN: llvm-readelf -S %t.so | FileCheck %s -check-prefix=SECTION
 # RUN: llvm-objdump -d %t.so | FileCheck %s
 
-# SECTION: .got.plt PROGBITS 00000000004002b8 0002b8 000018
+# SECTION: .got.plt PROGBITS 0000000000200248 000248 000018
 
-# 0x4002b8 (.got.plt) - 0x23c = 0x40007c = 4194428
+# 0x200248 (.got.plt) - 0x1cc = 0x20007c = 2097276
 # CHECK: <gotpc64>:
-# CHECK-NEXT: 23c: 7c 00 40 00 00 00 00 06       lea %s0, 4194428
+# CHECK-NEXT: 1cc: 7c 00 20 00 00 00 00 06       lea %s0, 2097276
 
 .global gotpc64
 gotpc64:

--- a/lld/test/ELF/ve-reloc-pic.s
+++ b/lld/test/ELF/ve-reloc-pic.s
@@ -8,11 +8,11 @@
 ## In PIC mode, it creates a relative relocation if the symbol is
 ## non-preemptable.
 
-# NM: 0000000000400318 d b
+# NM: 00000000002001f8 d b
 
 # RELOC:      .rela.dyn {
-# RELOC-NEXT:   0x400318 R_VE_RELATIVE - 0x400318
-# RELOC-NEXT:   0x400310 R_VE_REFQUAD a 0x0
+# RELOC-NEXT:   0x2001F8 R_VE_RELATIVE - 0x2001F8
+# RELOC-NEXT:   0x2001F0 R_VE_REFQUAD a 0x0
 # RELOC-NEXT: }
 
 .globl a, b

--- a/lld/test/ELF/ve-tls-gd.s
+++ b/lld/test/ELF/ve-tls-gd.s
@@ -27,14 +27,14 @@
 # RUN: llvm-objdump -d --no-show-raw-insn %t | FileCheck --check-prefix=IE %s
 
 # GD-REL:      .rela.dyn {
-# GD-REL-NEXT:   0x200578 R_VE_DTPMOD64 a 0x0
-# GD-REL-NEXT:   0x200580 R_VE_DTPOFF64 a 0x0
-# GD-REL-NEXT:   0x200588 R_VE_DTPMOD64 b 0x0
-# GD-REL-NEXT:   0x200590 R_VE_DTPOFF64 b 0x0
+# GD-REL-NEXT:   0x200508 R_VE_DTPMOD64 a 0x0
+# GD-REL-NEXT:   0x200510 R_VE_DTPOFF64 a 0x0
+# GD-REL-NEXT:   0x200518 R_VE_DTPMOD64 b 0x0
+# GD-REL-NEXT:   0x200520 R_VE_DTPOFF64 b 0x0
 # GD-REL-NEXT: }
 
-## &DTPMOD(a) - . = 0x200578 - 0x3a0 = 0 : 0x2001d8 = 0 : 2097640
-# GD:      390: lea %s0, 2097640(-24)
+## &DTPMOD(a) - . = 0x200508 - 0x330 = 0 : 0x2001d8 = 0 : 2097640
+# GD:      320: lea %s0, 2097640(-24)
 # GD-NEXT:         and %s0, %s0, (32)0
 # GD-NEXT:         sic %s10
 # GD-NEXT:         lea.sl %s0, (%s0, %s10)
@@ -43,8 +43,8 @@
 # GD-NEXT:         lea.sl %s12, (%s12, %s10)
 # GD-NEXT:         bsic %s10, (, %s12)
 
-## &DTPMOD(b) - . = 0x200588 - 0x3e0 = 0: 0x2001a8 = 0 : 2097592
-# GD:      3d0: lea %s0, 2097592(-24)
+## &DTPMOD(b) - . = 0x200518 - 0x370 = 0: 0x2001a8 = 0 : 2097592
+# GD:      360: lea %s0, 2097592(-24)
 # GD-NEXT:         and %s0, %s0, (32)0
 # GD-NEXT:         sic %s10
 # GD-NEXT:         lea.sl %s0, (%s0, %s10)
@@ -66,16 +66,16 @@
 ## a is local - relaxed to LE - its DTPMOD/DTPREL slots are link-time constants.
 ## b is external - DTPMOD/DTPREL dynamic relocations are required.
 # IE-REL:      .rela.dyn {
-# IE-REL-NEXT:   0x6000002003C0 R_VE_DTPMOD64 b 0x0
-# IE-REL-NEXT:   0x6000002003C8 R_VE_DTPOFF64 b 0x0
+# IE-REL-NEXT:   0x600000200388 R_VE_DTPMOD64 b 0x0
+# IE-REL-NEXT:   0x600000200390 R_VE_DTPOFF64 b 0x0
 # IE-REL-NEXT: }
 # IE-GOT:      section '.got':
-# IE-GOT-NEXT: 0x6000002003a8 e8022000 00600000 01000000 00000000
-# IE-GOT-NEXT: 0x6000002003b8 08000000 00000000 00000000 00000000
-# IE-GOT-NEXT: 0x6000002003c8 00000000 00000000
+# IE-GOT-NEXT: 0x600000200370 b0022000 00600000 01000000 00000000
+# IE-GOT-NEXT: 0x600000200380 08000000 00000000 00000000 00000000
+# IE-GOT-NEXT: 0x600000200390 00000000 00000000
 
-## &DTPMOD(a) - . = 0x6000002003b0 - 0x600000000278 = 0 : 0x200138 = 0 : 2097480
-# IE:      600000000268: lea %s0, 2097480(-24)
+## &DTPMOD(a) - . = 0x600000200378 - 0x600000000240 = 0 : 0x200138 = 0 : 2097480
+# IE:      600000000230: lea %s0, 2097480(-24)
 # IE-NEXT:               and %s0, %s0, (32)0
 # IE-NEXT:               sic %s10
 # IE-NEXT:               lea.sl %s0, (%s0, %s10)
@@ -84,8 +84,8 @@
 # IE-NEXT:               lea.sl %s12, (%s12, %s10)
 # IE-NEXT:               bsic %s10, (, %s12)
 
-## &DTPMOD(b) - . = 0x6000002003c0 - 0x6000000002b8 = 0 : 0x200108 = 0 : 2097432
-# IE:      6000000002a8: lea %s0, 2097432(-24)
+## &DTPMOD(b) - . = 0x600000200388 - 0x600000000280 = 0 : 0x200108 = 0 : 2097432
+# IE:      600000000270: lea %s0, 2097432(-24)
 # IE-NEXT:               and %s0, %s0, (32)0
 # IE-NEXT:               sic %s10
 # IE-NEXT:               lea.sl %s0, (%s0, %s10)

--- a/llvm/lib/Target/VE/VEISelLowering.cpp
+++ b/llvm/lib/Target/VE/VEISelLowering.cpp
@@ -2390,68 +2390,21 @@ bool VETargetLowering::shouldExpandBuildVectorWithShuffles(
 
 /// JumpTable for VE.
 ///
-///   VE cannot generate relocatable symbol in jump table.  VE cannot
-///   generate expressions using symbols in both text segment and data
-///   segment like below.
+///   In PIC mode, use EK_LabelDifference32 to generate jump table entries
+///   as offsets from the jump table label:
 ///             .4byte  .LBB0_2-.LJTI0_0
-///   So, we generate offset from the top of function like below as
-///   a custom label.
-///             .4byte  .LBB0_2-<function name>
+///   The jump table address is computed at runtime via GOTOFF (always valid
+///   since jump table labels are section-local).  This avoids using the
+///   function address as a base, which is problematic for exported functions
+///   in shared libraries due to ELF symbol interposition (GOT entries resolve
+///   to PLT stub canonical addresses, not the actual function body).
 
 unsigned VETargetLowering::getJumpTableEncoding() const {
-  // Use custom label for PIC.
   if (isPositionIndependent())
-    return MachineJumpTableInfo::EK_Custom32;
+    return MachineJumpTableInfo::EK_LabelDifference32;
 
   // Otherwise, use the normal jump table encoding heuristics.
   return TargetLowering::getJumpTableEncoding();
-}
-
-const MCExpr *VETargetLowering::LowerCustomJumpTableEntry(
-    const MachineJumpTableInfo *MJTI, const MachineBasicBlock *MBB,
-    unsigned Uid, MCContext &Ctx) const {
-  assert(isPositionIndependent());
-
-  // Generate custom label for PIC like below.
-  //    .4bytes  .LBB0_2-<function name>
-  const auto *Value = MCSymbolRefExpr::create(MBB->getSymbol(), Ctx);
-  MCSymbol *Sym = Ctx.getOrCreateSymbol(MBB->getParent()->getName().data());
-  const auto *Base = MCSymbolRefExpr::create(Sym, Ctx);
-  return MCBinaryExpr::createSub(Value, Base, Ctx);
-}
-
-SDValue VETargetLowering::getPICJumpTableRelocBase(SDValue Table,
-                                                   SelectionDAG &DAG) const {
-  assert(isPositionIndependent());
-  SDLoc DL(Table);
-  Function *Function = &DAG.getMachineFunction().getFunction();
-  assert(Function != nullptr);
-  auto PtrTy = getPointerTy(DAG.getDataLayout(), Function->getAddressSpace());
-
-  // In the jump table, we have following values in PIC mode.
-  //    .4bytes  .LBB0_2-<function name>
-  // We need to add this value and the address of this function to generate
-  // .LBB0_2 label correctly under PIC mode.  So, we want to generate following
-  // instructions:
-  //     lea %reg, fun@gotoff_lo
-  //     and %reg, %reg, (32)0
-  //     lea.sl %reg, fun@gotoff_hi(%reg, %got)
-  // In order to do so, we need to genarate correctly marked DAG node using
-  // makeHiLoPair.
-  SDValue Op = DAG.getGlobalAddress(Function, DL, PtrTy);
-  if (Function->hasLocalLinkage()) {
-    // Use GOTOFF for local linkage functions.
-    SDValue HiLo =
-        makeHiLoPair(Op, VE::S_GOTOFF_HI32, VE::S_GOTOFF_LO32, DAG);
-    SDValue GlobalBase = DAG.getNode(VEISD::GLOBAL_BASE_REG, DL, PtrTy);
-    return DAG.getNode(ISD::ADD, DL, PtrTy, GlobalBase, HiLo);
-  }
-  // Use GOT indirection for non-local linkage functions.
-  SDValue HiLo = makeHiLoPair(Op, VE::S_GOT_HI32, VE::S_GOT_LO32, DAG);
-  SDValue GlobalBase = DAG.getNode(VEISD::GLOBAL_BASE_REG, DL, PtrTy);
-  SDValue AbsAddr = DAG.getNode(ISD::ADD, DL, PtrTy, GlobalBase, HiLo);
-  return DAG.getLoad(PtrTy, DL, DAG.getEntryNode(), AbsAddr,
-                     MachinePointerInfo::getGOT(DAG.getMachineFunction()));
 }
 
 Register VETargetLowering::prepareMBB(MachineBasicBlock &MBB,
@@ -3038,13 +2991,12 @@ VETargetLowering::emitSjLjDispatchBlock(MachineInstr &MI,
         .addImm(0);
     break;
   }
-  case MachineJumpTableInfo::EK_Custom32: {
-    // Generate block address code using differences from the function pointer
-    // for PIC model.
+  case MachineJumpTableInfo::EK_LabelDifference32: {
+    // Generate block address code using signed offsets from the jump table
+    // label for PIC model.
     //     sll %Tmp1, %IReg, 2
-    //     ldl.zx %OReg, 0(%Tmp1, %BReg)
-    //     Prepare function address in BReg2.
-    //     adds.l %TReg, %BReg2, %OReg
+    //     ldl.sx %OReg, 0(%Tmp1, %BReg)   ; sign-extended load
+    //     adds.l %TReg, %BReg, %OReg
     //     bcfla %TReg
 
     assert(isPositionIndependent());
@@ -3055,17 +3007,13 @@ VETargetLowering::emitSjLjDispatchBlock(MachineInstr &MI,
     BuildMI(DispContBB, DL, TII->get(VE::SLLri), Tmp1)
         .addReg(IReg, getKillRegState(true))
         .addImm(2);
-    BuildMI(DispContBB, DL, TII->get(VE::LDLZXrri), OReg)
-        .addReg(BReg, getKillRegState(true))
+    BuildMI(DispContBB, DL, TII->get(VE::LDLSXrri), OReg)
+        .addReg(BReg)
         .addReg(Tmp1, getKillRegState(true))
         .addImm(0);
-    bool FuncIsLocal = MF->getFunction().hasLocalLinkage();
-    Register BReg2 =
-        prepareSymbol(*DispContBB, DispContBB->end(),
-                      DispContBB->getParent()->getName(), DL, FuncIsLocal);
     BuildMI(DispContBB, DL, TII->get(VE::ADDSLrr), TReg)
         .addReg(OReg, getKillRegState(true))
-        .addReg(BReg2, getKillRegState(true));
+        .addReg(BReg, getKillRegState(true));
     BuildMI(DispContBB, DL, TII->get(VE::BCFLari_t))
         .addReg(TReg, getKillRegState(true))
         .addImm(0);

--- a/llvm/lib/Target/VE/VEISelLowering.cpp
+++ b/llvm/lib/Target/VE/VEISelLowering.cpp
@@ -2682,6 +2682,19 @@ VETargetLowering::emitEHSjLjSetJmp(MachineInstr &MI,
     MIB.setMemRefs(MMOs);
   }
 
+  // Store GOT pointer (s15) in buf[4].  After SjLj longjmp, s15 may hold the
+  // GOT pointer of the unwinding library instead of the catching function's.
+  // Restoring s15 in RestoreMBB ensures PIC code in shared libraries works
+  // correctly after exception handling.
+  {
+    MachineInstrBuilder MIB = BuildMI(*MBB, MI, DL, TII->get(VE::STrii));
+    MIB.addReg(BufReg);
+    MIB.addImm(0);
+    MIB.addImm(32);
+    MIB.addReg(VE::SX15);
+    MIB.setMemRefs(MMOs);
+  }
+
   // Store IP in buf[1].
   MachineInstrBuilder MIB = BuildMI(*MBB, MI, DL, TII->get(VE::STrii));
   MIB.add(MI.getOperand(1)); // we can preserve the kill flags here.
@@ -2725,6 +2738,15 @@ VETargetLowering::emitEHSjLjSetJmp(MachineInstr &MI,
     MIB.addReg(VE::SX10);
     MIB.addImm(0);
     MIB.addImm(24);
+    MIB.setMemRefs(MMOs);
+  }
+  // Restore GOT pointer (s15) from buf[4].
+  {
+    MachineInstrBuilder MIB =
+        BuildMI(RestoreMBB, DL, TII->get(VE::LDrii), VE::SX15);
+    MIB.addReg(VE::SX10);
+    MIB.addImm(0);
+    MIB.addImm(32);
     MIB.setMemRefs(MMOs);
   }
   BuildMI(RestoreMBB, DL, TII->get(VE::LEAzii), RestoreDestReg)
@@ -2923,8 +2945,11 @@ VETargetLowering::emitSjLjDispatchBlock(MachineInstr &MI,
       .addRegMask(RI.getNoPreservedMask());
 
   if (isPositionIndependent()) {
-    // Force to generate GETGOT, since current implementation doesn't store GOT
-    // register.
+    // Restore GOT pointer in the dispatch block.  After SjLj longjmp from the
+    // unwinding library, s15 may hold the library's GOT pointer instead of the
+    // catching function's.  Unlike emitEHSjLjSetJmp's RestoreMBB path (which
+    // restores s15 from jbuf[4]), the C++ SjLj exception path lands directly
+    // in the dispatch block, so GETGOT is needed here.
     BuildMI(DispatchBB, DL, TII->get(VE::GETGOT), VE::SX15);
   }
 

--- a/llvm/lib/Target/VE/VEISelLowering.h
+++ b/llvm/lib/Target/VE/VEISelLowering.h
@@ -234,10 +234,6 @@ public:
 
   SDValue LowerOperation(SDValue Op, SelectionDAG &DAG) const override;
   unsigned getJumpTableEncoding() const override;
-  const MCExpr *LowerCustomJumpTableEntry(const MachineJumpTableInfo *MJTI,
-                                          const MachineBasicBlock *MBB,
-                                          unsigned Uid,
-                                          MCContext &Ctx) const override;
 
   // Lowering hooks.
   // Only used by VVP layer to intercept EVT-typed nodes before MVT widening
@@ -504,11 +500,6 @@ public:
   bool useLoadStackGuardNode(const Module &M) const override;
   void insertSSPDeclarations(Module &M,
                              const LibcallLoweringInfo &Libcalls) const override;
-
-  SDValue getPICJumpTableRelocBase(SDValue Table,
-                                   SelectionDAG &DAG) const override;
-  // VE doesn't need getPICJumpTableRelocBaseExpr since it is used for only
-  // EK_LabelDifference32.
 
   unsigned getSRetArgSize(SelectionDAG &DAG, SDValue Callee) const;
 

--- a/llvm/test/CodeGen/VE/Scalar/br_jt.ll
+++ b/llvm/test/CodeGen/VE/Scalar/br_jt.ll
@@ -656,10 +656,6 @@ define signext i32 @br_jt8_m(i32 signext %0, i32 signext %1) {
 ; PIC-NEXT:    and %s3, %s3, (32)0
 ; PIC-NEXT:    lea.sl %s3, .LJTI7_0@gotoff_hi(%s3, %s15)
 ; PIC-NEXT:    ldl.sx %s0, (%s0, %s3)
-; PIC-NEXT:    lea %s3, br_jt8_m@got_lo
-; PIC-NEXT:    and %s3, %s3, (32)0
-; PIC-NEXT:    lea.sl %s3, br_jt8_m@got_hi(, %s3)
-; PIC-NEXT:    ld %s3, (%s3, %s15)
 ; PIC-NEXT:    and %s1, %s1, (32)0
 ; PIC-NEXT:    adds.l %s3, %s3, %s0
 ; PIC-NEXT:    or %s0, 3, (0)1

--- a/llvm/test/CodeGen/VE/Scalar/builtin_sjlj.ll
+++ b/llvm/test/CodeGen/VE/Scalar/builtin_sjlj.ll
@@ -34,12 +34,14 @@ define signext i32 @t_setjmp() {
 ; CHECK-NEXT:    lea %s1, .LBB{{[0-9]+}}_3@lo
 ; CHECK-NEXT:    and %s1, %s1, (32)0
 ; CHECK-NEXT:    lea.sl %s1, .LBB{{[0-9]+}}_3@hi(, %s1)
+; CHECK-NEXT:    st %s15, 32(, %s0)
 ; CHECK-NEXT:    st %s1, 8(, %s0)
 ; CHECK-NEXT:    # EH_SJlJ_SETUP .LBB{{[0-9]+}}_3
 ; CHECK-NEXT:  # %bb.1:
 ; CHECK-NEXT:    lea %s0, 0
 ; CHECK-NEXT:    br.l.t .LBB{{[0-9]+}}_2
 ; CHECK-NEXT:  .LBB{{[0-9]+}}_3: # Block address taken
+; CHECK-NEXT:    ld %s15, 32(, %s10)
 ; CHECK-NEXT:    lea %s0, 1
 ; CHECK-NEXT:  .LBB{{[0-9]+}}_2:
 ; CHECK-NEXT:    adds.w.sx %s0, %s0, (0)1
@@ -109,12 +111,14 @@ define signext i32 @t_setjmp() {
 ; PIC-NEXT:    lea %s1, .LBB0_3@gotoff_lo
 ; PIC-NEXT:    and %s1, %s1, (32)0
 ; PIC-NEXT:    lea.sl %s1, .LBB0_3@gotoff_hi(%s1, %s15)
+; PIC-NEXT:    st %s15, 32(, %s0)
 ; PIC-NEXT:    st %s1, 8(, %s0)
 ; PIC-NEXT:    # EH_SJlJ_SETUP .LBB0_3
 ; PIC-NEXT:  # %bb.1:
 ; PIC-NEXT:    lea %s0, 0
 ; PIC-NEXT:    br.l.t .LBB0_2
 ; PIC-NEXT:  .LBB0_3: # Block address taken
+; PIC-NEXT:    ld %s15, 32(, %s10)
 ; PIC-NEXT:    lea %s0, 1
 ; PIC-NEXT:  .LBB0_2:
 ; PIC-NEXT:    adds.w.sx %s0, %s0, (0)1

--- a/llvm/test/CodeGen/VE/Scalar/builtin_sjlj_bp.ll
+++ b/llvm/test/CodeGen/VE/Scalar/builtin_sjlj_bp.ll
@@ -38,6 +38,7 @@ define i32 @t_setjmp(i64 %n, ptr byval(%Foo) nocapture readnone align 8 %f) {
 ; CHECK-NEXT:    and %s0, %s0, (32)0
 ; CHECK-NEXT:    lea.sl %s0, .LBB{{[0-9]+}}_3@hi(, %s0)
 ; CHECK-NEXT:    st %s17, 24(, %s1)
+; CHECK-NEXT:    st %s15, 32(, %s1)
 ; CHECK-NEXT:    st %s1, 296(, %s17) # 8-byte Folded Spill
 ; CHECK-NEXT:    st %s0, 8(, %s1)
 ; CHECK-NEXT:    # EH_SJlJ_SETUP .LBB{{[0-9]+}}_3
@@ -46,6 +47,7 @@ define i32 @t_setjmp(i64 %n, ptr byval(%Foo) nocapture readnone align 8 %f) {
 ; CHECK-NEXT:    br.l.t .LBB{{[0-9]+}}_2
 ; CHECK-NEXT:  .LBB{{[0-9]+}}_3: # Block address taken
 ; CHECK-NEXT:    ld %s17, 24(, %s10)
+; CHECK-NEXT:    ld %s15, 32(, %s10)
 ; CHECK-NEXT:    lea %s5, 1
 ; CHECK-NEXT:  .LBB{{[0-9]+}}_2:
 ; CHECK-NEXT:    lea %s0, whatever@lo

--- a/llvm/test/CodeGen/VE/Scalar/builtin_sjlj_callsite.ll
+++ b/llvm/test/CodeGen/VE/Scalar/builtin_sjlj_callsite.ll
@@ -244,11 +244,7 @@ define void @test_callsite() personality ptr @__gxx_personality_sj0 {
 ; PIC-NEXT:    and %s1, %s1, (32)0
 ; PIC-NEXT:    lea.sl %s1, .LJTI0_0@gotoff_hi(%s1, %s15)
 ; PIC-NEXT:    sll %s0, %s0, 2
-; PIC-NEXT:    ldl.zx %s0, (%s0, %s1)
-; PIC-NEXT:    lea %s1, test_callsite@got_lo
-; PIC-NEXT:    and %s1, %s1, (32)0
-; PIC-NEXT:    lea.sl %s1, test_callsite@got_hi(%s1, %s15)
-; PIC-NEXT:    ld %s1, (, %s1)
+; PIC-NEXT:    ldl.sx %s0, (%s0, %s1)
 ; PIC-NEXT:    adds.l %s0, %s0, %s1
 ; PIC-NEXT:    b.l.t (, %s0)
 ; PIC-NEXT:  .LBB0_1: # %lpad

--- a/llvm/test/CodeGen/VE/Scalar/builtin_sjlj_landingpad.ll
+++ b/llvm/test/CodeGen/VE/Scalar/builtin_sjlj_landingpad.ll
@@ -243,11 +243,7 @@ define dso_local i32 @foo(i32 %arg) local_unnamed_addr personality ptr @__gxx_pe
 ; PIC-NEXT:    and %s1, %s1, (32)0
 ; PIC-NEXT:    lea.sl %s1, .LJTI0_0@gotoff_hi(%s1, %s15)
 ; PIC-NEXT:    sll %s0, %s0, 2
-; PIC-NEXT:    ldl.zx %s0, (%s0, %s1)
-; PIC-NEXT:    lea %s1, foo@got_lo
-; PIC-NEXT:    and %s1, %s1, (32)0
-; PIC-NEXT:    lea.sl %s1, foo@got_hi(%s1, %s15)
-; PIC-NEXT:    ld %s1, (, %s1)
+; PIC-NEXT:    ldl.sx %s0, (%s0, %s1)
 ; PIC-NEXT:    adds.l %s0, %s0, %s1
 ; PIC-NEXT:    b.l.t (, %s0)
 ; PIC-NEXT:  .LBB0_6: # %handle


### PR DESCRIPTION
## Summary

Four related fixes for VE PIC code in shared libraries:

### 1. Save/restore s15 (GOT pointer) in SjLj exception handling paths

- Save s15 in jbuf[4] during `EH_SJlJ_SETUP` and restore in `RestoreMBB` after longjmp returns (builtin setjmp/longjmp path)
- Restore s15 via `GETGOT` in the SjLj dispatch block for PIC code (C++ SjLj exception path)

After SjLj longjmp, s15 may hold the GOT pointer of the unwinding library instead of the catching function's. This causes SIGILL/SIGSEGV when PIC code references global data through a stale GOT base.

Complements PR #448 which saves/restores s15/s16 in prologue/epilogue of SjLj functions.

### 2. Use EK_LabelDifference32 for PIC jump tables instead of EK_Custom32

Switch PIC jump table encoding from `EK_Custom32` (`MBB - function_name`) to `EK_LabelDifference32` (`MBB - JT_label`).

The previous approach used the function address as the jump table base, loaded via GOT for non-local functions. For exported functions in shared libraries, GOT entries resolve to PLT stub canonical addresses (due to ELF symbol interposition) rather than the actual function body, causing incorrect jump targets.

`EK_LabelDifference32` uses the jump table label as the base, computed via GOTOFF which is always valid since JT labels are section-local. This is the standard approach used by AArch64, RISCV, SystemZ, PowerPC, and Sparc.

This removes `LowerCustomJumpTableEntry` and `getPICJumpTableRelocBase` entirely, as they are no longer needed.

### 3. Place .text before .rodata to work around VEOS AT_PHDR bug

VEOS calculates `AT_PHDR` from the entry point's page base address plus `e_phoff`, instead of using the ELF load address. When a large `.rodata` section pushes `.text` (and thus the entry point) past the 2 MB VE page boundary, `AT_PHDR` points to the wrong address and the dynamic linker fails with an assertion in `dl_main`.

Fix: swap `RF_EXEC` and `RF_RODATA` ranks in `getSectionRank()` for VE so that `.text` is placed before `.rodata`, keeping the entry point in the first page.

### 4. Update lld test expectations

Update CHECK lines in 7 VE lld tests to match the new section layout where `.text` precedes `.rodata` in the R E segment.

## Test plan

- [x] check-llvm: 37,436 Passed, 0 Failed
- [x] check-lld: 2,054 Passed, 0 Failed
- [x] check-libcxxabi: 55 Passed, 0 Failed (test_vector1, test_vector2, test_demangle now PASS)
- [x] check-compiler-rt: 237 Passed, 0 Failed
- [x] Internal regression tests