### PR TITLE
[VE] Switch default exception handling to DWARF CFI

### DIFF
--- a/clang/lib/Basic/Targets/VE.h
+++ b/clang/lib/Basic/Targets/VE.h
@@ -187,6 +187,12 @@ public:
     return false;
   }
 
+  // Exception pointer is stored in s0, and exception selector in s1.
+  // Their DWARF register numbers are 0 and 1 respectively.
+  int getEHDataRegisterNumber(unsigned RegNo) const override {
+    return RegNo < 2 ? RegNo : -1;
+  }
+
   bool allowsLargerPreferedTypeAlignment() const override { return false; }
 };
 } // namespace targets

--- a/clang/lib/Driver/ToolChains/VEToolchain.cpp
+++ b/clang/lib/Driver/ToolChains/VEToolchain.cpp
@@ -161,6 +161,7 @@ void VEToolChain::AddCXXStdlibLibArgs(const ArgList &Args,
 
 llvm::ExceptionHandling
 VEToolChain::GetExceptionModel(const ArgList &Args) const {
-  // VE uses SjLj exceptions.
-  return llvm::ExceptionHandling::SjLj;
+  // VE defaults to DWARF CFI-based zero-cost exception handling.
+  // SjLj can be selected with -fsjlj-exceptions.
+  return llvm::ExceptionHandling::DwarfCFI;
 }

--- a/clang/test/Driver/ve-toolchain.c
+++ b/clang/test/Driver/ve-toolchain.c
@@ -88,7 +88,7 @@
 // DEF:      clang{{.*}}" "-cc1"
 // DEF-SAME: "-resource-dir" "[[RESOURCE_DIR:[^"]+]]"
 // DEF-SAME: "-isysroot" "[[SYSROOT:[^"]+]]"
-// DEF-SAME: "-exception-model=sjlj"
+// DEF-SAME: "-exception-model=dwarf"
 // DEF:      ld.lld"
 // DEF-SAME: "--sysroot=[[SYSROOT]]"
 // DEF-SAME: "-dynamic-linker" "/opt/nec/ve/lib/ld-linux-ve.so.1"

--- a/clang/test/Driver/ve-toolchain.cpp
+++ b/clang/test/Driver/ve-toolchain.cpp
@@ -139,7 +139,7 @@
 // DEF:      "-cc1"
 // DEF-SAME: "-resource-dir" "[[RESOURCE_DIR:[^"]+]]"
 // DEF-SAME: "-isysroot" "[[SYSROOT:[^"]+]]"
-// DEF-SAME: "-exception-model=sjlj"
+// DEF-SAME: "-exception-model=dwarf"
 // DEF:      ld.lld"
 // DEF-SAME: "--sysroot=[[SYSROOT]]"
 // DEF-SAME: "-dynamic-linker" "/opt/nec/ve/lib/ld-linux-ve.so.1"

--- a/libunwind/test/forceunwind.pass.cpp
+++ b/libunwind/test/forceunwind.pass.cpp
@@ -11,9 +11,6 @@
 // UNSUPPORTED: target={{.*-aix.*}}
 // UNSUPPORTED: target={{.*-windows.*}}
 
-// VE does not yet support the zero-cost unwinding APIs.
-// XFAIL: target=ve-{{.*}}
-
 // TODO: Figure out why this fails with Memory Sanitizer.
 // XFAIL: msan
 

--- a/libunwind/test/libunwind_01.pass.cpp
+++ b/libunwind/test/libunwind_01.pass.cpp
@@ -10,9 +10,6 @@
 // TODO: Investigate this failure on x86_64 macOS back deployment
 // XFAIL: stdlib=system && target=x86_64-apple-macosx{{10.9|10.10|10.11|10.12|10.13|10.14|10.15|11.0|12.0}}
 
-// VE does not yet support the zero-cost unwinding APIs.
-// XFAIL: target=ve-{{.*}}
-
 // TODO: Figure out why this fails with Memory Sanitizer.
 // XFAIL: msan
 

--- a/libunwind/test/libunwind_02.pass.cpp
+++ b/libunwind/test/libunwind_02.pass.cpp
@@ -7,9 +7,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-// VE does not yet support the zero-cost unwinding APIs.
-// XFAIL: target=ve-{{.*}}
-
 // TODO: Figure out why this fails with Memory Sanitizer.
 // XFAIL: msan
 

--- a/libunwind/test/signal_frame.pass.cpp
+++ b/libunwind/test/signal_frame.pass.cpp
@@ -15,9 +15,6 @@
 // TODO: Figure out why this fails with Memory Sanitizer.
 // XFAIL: msan
 
-// VE does not yet support the zero-cost unwinding APIs.
-// XFAIL: target=ve-{{.*}}
-
 // UNSUPPORTED: libunwind-arm-ehabi
 
 // The AIX assembler does not support CFI directives, which

--- a/libunwind/test/unw_getcontext.pass.cpp
+++ b/libunwind/test/unw_getcontext.pass.cpp
@@ -7,9 +7,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-// VE does not yet support the zero-cost unwinding APIs.
-// XFAIL: target=ve-{{.*}}
-
 #undef NDEBUG
 #include <assert.h>
 #include <libunwind.h>

--- a/libunwind/test/unw_resume.pass.cpp
+++ b/libunwind/test/unw_resume.pass.cpp
@@ -10,9 +10,6 @@
 // Ensure that unw_resume() resumes execution at the stack frame identified by
 // cursor.
 
-// VE does not yet support the zero-cost unwinding APIs.
-// XFAIL: target=ve-{{.*}}
-
 // TODO: Figure out why this fails with Memory Sanitizer.
 // XFAIL: msan
 


### PR DESCRIPTION
## Summary
- Switch VE default exception model from SjLj to DWARF CFI in `VEToolchain.cpp`
- Define `getEHDataRegisterNumber()` in `VE.h` so that `__builtin_eh_return_data_regno()` returns correct DWARF register numbers (s0=0, s1=1) for the personality handler
- Update driver tests (`ve-toolchain.c`, `ve-toolchain.cpp`) to expect `-exception-model=dwarf`
- Remove VE XFAILs from 6 libunwind tests that now pass with DWARF unwinding

## Dependencies
- Requires PR #450 (DWARF EH infrastructure) to be merged first

## Test results
- [x] check-compiler-rt: 237 Passed, 0 Failed
- [x] check-libunwind: 8 Passed, 0 Failed (previously 2 Passed + 6 XFAIL)
- [x] check-libcxxabi: 54 Passed, 1 Failed (cxa_vec_new_overflow_PR41395 — pre-existing issue)
- [x] check-clang: 45270 Passed, 2 Failed (ve-toolchain tests — fixed in this PR)
- [x] Internal regression tests