### PR TITLE
[lld][VE] Clean up for upstream submission

### DIFF
--- a/lld/ELF/Arch/VE.cpp
+++ b/lld/ELF/Arch/VE.cpp
@@ -108,13 +108,6 @@ RelExpr VE::getRelExpr(RelType type, const Symbol &s,
   case R_VE_PLT_HI32:
   case R_VE_PLT_LO32:
     return R_PLT_PC;
-#if 0
-  case R_VE_RELATIVE:
-  case R_VE_GLOB_DAT:
-  case R_VE_JUMP_SLOT:
-  case R_VE_COPY:
-  case R_VE_DTPMOD64:
-#endif
   case R_VE_DTPOFF64:
     return R_DTPREL;
   case R_VE_TLS_GD_HI32:
@@ -150,32 +143,22 @@ void VE::relocate(uint8_t *loc, const Relocation &rel,
     write32le(loc, val);
     break;
   case R_VE_HI32:
-  case R_VE_PC_HI32:    // OK
-  case R_VE_GOT_HI32:   // OK
-  case R_VE_GOTOFF_HI32:// OK
-  case R_VE_PLT_HI32:   // OK
+  case R_VE_PC_HI32:
+  case R_VE_GOT_HI32:
+  case R_VE_GOTOFF_HI32:
+  case R_VE_PLT_HI32:
     write32le(loc, val >> 32);
     break;
   case R_VE_LO32:
-  case R_VE_PC_LO32:    // OK
+  case R_VE_PC_LO32:
   case R_VE_GOT32:
-  case R_VE_GOT_LO32:   // OK
+  case R_VE_GOT_LO32:
   case R_VE_GOTOFF32:
-  case R_VE_GOTOFF_LO32:// OK
+  case R_VE_GOTOFF_LO32:
   case R_VE_PLT32:
-  case R_VE_PLT_LO32:   // OK
+  case R_VE_PLT_LO32:
     write32le(loc, val);
     break;
-#if 0
-  case R_VE_RELATIVE:
-  case R_VE_GLOB_DAT:
-  case R_VE_JUMP_SLOT:
-    checkInt(loc, val, 64, rel);
-    write64le(loc, val);
-    break;
-  case R_VE_COPY:
-  case R_VE_DTPMOD64:
-#endif
   case R_VE_DTPOFF64:
     write64le(loc, val);
     break;
@@ -242,8 +225,9 @@ int64_t VE::getImplicitAddend(const uint8_t *buf, RelType type) const {
 }
 
 RelExpr VE::adjustTlsExpr(RelType type, RelExpr expr) const {
+  // GD to LE relaxation is defined in the VE TLS ABI but not yet implemented.
+  // Returning R_NONE disables TLS optimization.
   return R_NONE;
-  // return expr;
 }
 
 void VE::writeGotPltHeader(uint8_t *buf) const {

--- a/lld/ELF/Driver.cpp
+++ b/lld/ELF/Driver.cpp
@@ -3418,14 +3418,16 @@ template <class ELFT> void LinkerDriver::link(opt::InputArgList &args) {
   // values such as a default image base address.
   setTarget(ctx);
 
-  // VE dynamic linker does not support separate RO and RX segments.
+  // The VE dynamic linker (VEOS) does not distinguish RO and RX segments;
+  // it maps all non-writable PT_LOAD segments as PROT_READ|PROT_EXEC.
+  // Merging them avoids an unnecessary LOAD segment.
   if (ctx.arg.emachine == EM_VE &&
       !args.hasArg(OPT_rosegment) && !args.hasArg(OPT_no_rosegment))
     ctx.arg.singleRoRx = true;
 
-  // VE does not need RELRO.  The extra LOAD segment and .relro_padding
-  // waste real memory on VE, where virtual address space is committed at
-  // map time rather than on access.
+  // The VE dynamic linker (VEOS) does not process PT_GNU_RELRO.
+  // The extra LOAD segment and .relro_padding waste real memory on VE,
+  // where virtual address space is committed at map time rather than on access.
   if (ctx.arg.emachine == EM_VE && !hasZOption(args, "relro"))
     ctx.arg.zRelro = false;
 

--- a/lld/ELF/Writer.cpp
+++ b/lld/ELF/Writer.cpp
@@ -801,11 +801,10 @@ unsigned elf::getSectionRank(Ctx &ctx, OutputSection &osec) {
   }
 
   if (ctx.arg.emachine == EM_VE) {
-    // VEOS calculates AT_PHDR from the entry point's page base address,
-    // so the entry point must reside in the first page.  Place executable
-    // sections (.text) before read-only data (.rodata) to keep .text near
-    // the start of the R E segment and prevent a large .rodata from
-    // pushing the entry point past the 2 MB page boundary.
+    // VEOS calculates AT_PHDR as (e_entry & ~(page_size - 1)) + sizeof(Ehdr),
+    // assuming the ELF header is at the page base of the entry point.
+    // Place .text before .rodata so that a large .rodata does not push
+    // the entry point past the first page boundary.
     if (rank & RF_EXEC)
       rank = (rank & ~RF_EXEC) | RF_RODATA;
     else if (rank & RF_RODATA)


### PR DESCRIPTION
## Summary
- Remove `#if 0` blocks (dead dynamic relocation handling in `getRelExpr`/`relocate`)
- Remove development memo comments (`// OK`, `// return expr;`)
- Add explanatory comments for `adjustTlsExpr` (TLS relaxation not yet implemented)
- Improve comments in `Driver.cpp` (singleRoRx, zRelro) with VEOS source references
- Improve comments in `Writer.cpp` (.text/.rodata ordering) with VEOS AT_PHDR calculation

## Details
Preparation for upstream submission of lld VE support. See `ve-lld-upstream-review.md` for full review notes.

## Test plan
- [x] check-llvm: 38151 passed
- [x] check-lld: 2055 passed