### PR TITLE
[VE] Set COMPILER_RT_EMULATOR for lit timeout support

### DIFF
--- a/clang/cmake/caches/VectorEngine.cmake
+++ b/clang/cmake/caches/VectorEngine.cmake
@@ -87,6 +87,11 @@ set(RUNTIMES_ve-unknown-linux-gnu_OPENMP_ENABLE_LIBOMPTARGET FALSE CACHE BOOL ""
 # VE requires -lrt flag for shm_open.
 set(RUNTIMES_ve-unknown-linux-gnu_LIBOMP_HAVE_SHM_OPEN_WITH_LRT TRUE CACHE BOOL "")
 
+# Use ve_exec as emulator so that lit can manage VE process tree for
+# timeout support. Without this, binfmt_misc launches ve_exec transparently
+# and lit cannot kill timed-out processes.
+set(RUNTIMES_ve-unknown-linux-gnu_COMPILER_RT_EMULATOR "ve_exec" CACHE STRING "")
+
 # Compiler flags for testing
 set(RUNTIMES_ve-unknown-linux-gnu_COMPILER_RT_TEST_COMPILER_CFLAGS "--target=ve-unknown-linux-gnu" CACHE BOOL "")
 set(RUNTIMES_ve-unknown-linux-gnu_LIBCXXABI_TEST_COMPILER_CFLAGS "--target=ve-unknown-linux-gnu" CACHE BOOL "")

--- a/compiler-rt/test/profile/instrprof-hostname.c
+++ b/compiler-rt/test/profile/instrprof-hostname.c
@@ -3,7 +3,8 @@
 // RUN: %run uname -n | tr -d '\n' > %t.n
 // RUN: llvm-profdata merge -o %t.profdata %{readfile:%t.n}.%t-%{readfile:%t.n}.profraw_%{readfile:%t.n}
 // RUN: %clang_profuse=%t.profdata -o - -S -emit-llvm %s | FileCheck %s
-// Requires uname
+// Requires uname which is a host command unavailable via emulator.
+// REQUIRES: native-run
 // UNSUPPORTED: system-windows
 
 int main(int argc, const char *argv[]) {

--- a/compiler-rt/test/profile/lit.cfg.py
+++ b/compiler-rt/test/profile/lit.cfg.py
@@ -186,3 +186,6 @@ if config.have_curl:
 
 if config.target_os in ("AIX", "Darwin", "Linux"):
     config.available_features.add("continuous-mode")
+
+if not config.emulator:
+    config.available_features.add("native-run")


### PR DESCRIPTION
## Summary
- Set `COMPILER_RT_EMULATOR=ve_exec` in VectorEngine.cmake so that lit can manage the VE process tree and enforce `--timeout`
- Without this, binfmt_misc launches ve_exec transparently and lit cannot kill timed-out test processes (e.g. `instrprof-gcov-multithread_fork.test` hangs indefinitely)
- Add `native-run` feature to profile lit config, matching the existing pattern in builtins lit config
- Mark `instrprof-hostname.c` as `REQUIRES: native-run` since it uses host commands (`uname`) unavailable via emulator

## Test plan
- [x] check-compiler-rt: 234 Passed, 0 Failed (instrprof-hostname.c correctly marked as Unsupported)
- [x] Verified lit `--timeout=10` correctly kills a hanging VE process via emulator
- [x] libcxx/libcxxabi/libunwind unaffected (they use run.py which maintains process tree via binfmt_misc)