### PR TITLE
[VE] Support vector mask registers in inline assembly

### DIFF
--- a/clang/lib/CodeGen/Targets/VE.cpp
+++ b/clang/lib/CodeGen/Targets/VE.cpp
@@ -8,9 +8,29 @@
 
 #include "ABIInfoImpl.h"
 #include "TargetInfo.h"
+#include "llvm/IR/DerivedTypes.h"
 
 using namespace clang;
 using namespace clang::CodeGen;
+
+// Rewrite the type of inline asm operands for vector mask registers.
+// ConvertTypeForMem converts ext_vector_type(256) bool to i256 for memory
+// representation, but inline asm with "v" constraint needs <256 x i1> to
+// select VMRegClass instead of V64RegClass.
+static llvm::Type *VEAdjustInlineAsmType(CodeGen::CodeGenFunction &CGF,
+                                         StringRef Constraint,
+                                         llvm::Type *Ty) {
+  if (Constraint == "v") {
+    if (auto *IntTy = dyn_cast<llvm::IntegerType>(Ty)) {
+      unsigned BitWidth = IntTy->getBitWidth();
+      if (BitWidth == 256 || BitWidth == 512) {
+        llvm::Type *Int1Ty = llvm::Type::getInt1Ty(CGF.getLLVMContext());
+        return llvm::FixedVectorType::get(Int1Ty, BitWidth);
+      }
+    }
+  }
+  return Ty;
+}
 
 //===----------------------------------------------------------------------===//
 // VE ABI Implementation.
@@ -61,6 +81,12 @@ public:
   bool isNoProtoCallVariadic(const CallArgList &args,
                              const FunctionNoProtoType *fnType) const override {
     return true;
+  }
+
+  llvm::Type *adjustInlineAsmType(CodeGen::CodeGenFunction &CGF,
+                                  StringRef Constraint,
+                                  llvm::Type *Ty) const override {
+    return VEAdjustInlineAsmType(CGF, Constraint, Ty);
   }
 };
 } // end anonymous namespace

--- a/clang/test/CodeGen/VE/ve-inline-asm.c
+++ b/clang/test/CodeGen/VE/ve-inline-asm.c
@@ -21,3 +21,16 @@ void v(char *ptr, char *ptr2) {
   // CHECK: %1 = call <256 x double> asm "vld $0, 8, $1", "=v,r"(ptr %0)
   // CHECK: call void asm sideeffect "vst $0, 8, $1", "v,r"(<256 x double> %2, ptr %3)
 }
+
+void vm(long val) {
+  typedef _Bool __vm __attribute__((ext_vector_type(256)));
+  __vm m;
+  asm("lvm %0, 0, %1"
+      : "=v"(m)
+      : "r"(val));
+  asm("svm %0, %1, 0"
+      : "=r"(val)
+      : "v"(m));
+  // CHECK: %1 = call <256 x i1> asm "lvm $0, 0, $1", "=v,r"(i64 %0)
+  // CHECK: %4 = call i64 asm "svm $0, $1, 0", "=r,v"(<256 x i1> %3)
+}

--- a/llvm/lib/Target/VE/VEISelLowering.cpp
+++ b/llvm/lib/Target/VE/VEISelLowering.cpp
@@ -3921,7 +3921,12 @@ VETargetLowering::getRegForInlineAsmConstraint(const TargetRegisterInfo *TRI,
       RC = &VE::I64RegClass;
       break;
     case 'v':
-      RC = &VE::V64RegClass;
+      if (VT == MVT::v256i1)
+        RC = &VE::VMRegClass;
+      else if (VT == MVT::v512i1)
+        RC = &VE::VM512RegClass;
+      else
+        RC = &VE::V64RegClass;
       break;
     case 'f':
       if (VT == MVT::f32 || VT == MVT::f64)

--- a/llvm/test/CodeGen/VE/Scalar/inlineasm-vm.ll
+++ b/llvm/test/CodeGen/VE/Scalar/inlineasm-vm.ll
@@ -1,0 +1,16 @@
+; RUN: llc < %s -mtriple=ve -mattr=+vpu | FileCheck %s
+
+define void @lvm_svm(ptr %p) nounwind {
+; CHECK-LABEL: lvm_svm:
+; CHECK:       # %bb.0:
+; CHECK-NEXT:    #APP
+; CHECK-NEXT:    lvm %vm1, 0, %s0
+; CHECK-NEXT:    #NO_APP
+; CHECK-NEXT:    #APP
+; CHECK-NEXT:    svm %s0, %vm1, 0
+; CHECK-NEXT:    #NO_APP
+; CHECK-NEXT:    b.l.t (, %s10)
+  %1 = tail call <256 x i1> asm sideeffect "lvm $0, 0, $1", "=v,r"(ptr %p) nounwind
+  %2 = tail call i64 asm sideeffect "svm $0, $1, 0", "=r,v"(<256 x i1> %1) nounwind
+  ret void
+}


### PR DESCRIPTION
## Summary

- Add type-based dispatch for `v` constraint in `getRegForInlineAsmConstraint`: `v256i1` → `VMRegClass`, `v512i1` → `VM512RegClass`
- Implement `adjustInlineAsmType` for VE target in Clang to convert `i256`/`i512` back to `<256 x i1>`/`<512 x i1>` when used with `v` constraint (same pattern as X86's `k` constraint for AVX-512 mask registers)
- Add LLVM CodeGen test (`inlineasm-vm.ll`) and Clang CodeGen test (`ve-inline-asm.c`)

## Background

Clang's `ConvertTypeForMem` converts `ext_vector_type(256) bool` (`__vm`) to `i256` for memory representation. For inline asm output operands, this `i256` type was passed to the backend, which mapped it to `V64RegClass` (vector registers) instead of `VMRegClass` (vector mask registers), causing assembly errors like `lvm %v0, ...` instead of `lvm %vm0, ...`.

## Test plan

- [x] check-llvm passed
- [x] check-clang passed