### PR TITLE
[VE] Enable CFIFixup pass for correct DWARF unwind info

### DIFF
--- a/llvm/lib/Target/VE/VETargetMachine.cpp
+++ b/llvm/lib/Target/VE/VETargetMachine.cpp
@@ -66,6 +66,8 @@ VETargetMachine::VETargetMachine(const Target &T, const Triple &TT,
       Subtarget(TT, std::string(CPU), std::string(FS), *this) {
   // FIXME: Issue FastISel in packed mode. Disabling it for now.
   setFastISel(false);
+  // VE supports fixing up the DWARF unwind information.
+  setCFIFixup(true);
   initAsmInfo();
 }
 

--- a/llvm/test/CodeGen/VE/Scalar/exception.ll
+++ b/llvm/test/CodeGen/VE/Scalar/exception.ll
@@ -31,6 +31,7 @@ define void @cleanup(ptr %p) personality ptr @__gxx_personality_v0 {
 ; CHECK-NEXT:    st %s19, 56(, %s9) # 8-byte Folded Spill
 ; CHECK-NEXT:    .cfi_offset %s18, 48
 ; CHECK-NEXT:    .cfi_offset %s19, 56
+; CHECK-NEXT:    .cfi_remember_state
 ; CHECK-NEXT:    or %s18, 0, %s0
 ; CHECK-NEXT:  .Ltmp0: # EH_LABEL
 ; CHECK-NEXT:    lea %s0, foo@lo
@@ -52,6 +53,7 @@ define void @cleanup(ptr %p) personality ptr @__gxx_personality_v0 {
 ; CHECK-NEXT:    .cfi_restore %s9
 ; CHECK-NEXT:    b.l.t (, %s10)
 ; CHECK-NEXT:  .LBB0_2: # %lpad
+; CHECK-NEXT:    .cfi_restore_state
 ; CHECK-NEXT:  .Ltmp2: # EH_LABEL
 ; CHECK-NEXT:    or %s19, 0, %s0
 ; CHECK-NEXT:    lea %s0, bar@lo
@@ -86,6 +88,7 @@ define void @catch(ptr %p) personality ptr @__gxx_personality_v0 {
 ; CHECK-NEXT:    .cfi_offset %s10, 8
 ; CHECK-NEXT:    or %s9, 0, %s11
 ; CHECK-NEXT:    .cfi_def_cfa_register %s9
+; CHECK-NEXT:    .cfi_remember_state
 ; CHECK-NEXT:    lea %s11, -240(, %s11)
 ; CHECK-NEXT:    brge.l %s11, %s8, .LBB1_4
 ; CHECK-NEXT:  # %bb.3: # %entry
@@ -113,6 +116,7 @@ define void @catch(ptr %p) personality ptr @__gxx_personality_v0 {
 ; CHECK-NEXT:    .cfi_restore %s9
 ; CHECK-NEXT:    b.l.t (, %s10)
 ; CHECK-NEXT:  .LBB1_1: # %lpad
+; CHECK-NEXT:    .cfi_restore_state
 ; CHECK-NEXT:  .Ltmp5: # EH_LABEL
 ; CHECK-NEXT:    lea %s1, bar@lo
 ; CHECK-NEXT:    and %s1, %s1, (32)0


### PR DESCRIPTION
## Summary
- Enable the CFIFixup pass for VE by calling `setCFIFixup(true)` in `VETargetMachine`
- Without this, code placed after function epilogues (e.g., exception throw paths) has incorrect DWARF CFI state, causing callee-saved registers not to be restored during unwinding
- This fixes crashes in libc++ locale construction when throwing exceptions (e.g., `locale("spazbot")`)

## Details
When LLVM reorders basic blocks such that an error/exception path appears after the function epilogue, the CFI directives from the epilogue (`.cfi_restore`) cause the unwinder to think callee-saved registers are already restored. The CFIFixup pass inserts `cfi_remember_state`/`cfi_restore_state` pairs to maintain correct CFI state across such reorderings. AArch64 already enables this pass.

## Test plan
- [x] Verified `cfi_remember_state`/`cfi_restore_state` are emitted in assembly output
- [x] `char_pointer.pass.cpp` (libcxx locale test) now passes
- [x] check-llvm
- [x] Internal regression tests