### PR TITLE
[VE] Remove XFAIL for gps_time ostream test

### DIFF
--- a/libcxx/test/std/time/time.clock/time.clock.gps/gps_time.ostream.pass.cpp
+++ b/libcxx/test/std/time/time.clock/time.clock.gps/gps_time.ostream.pass.cpp
@@ -16,10 +16,6 @@
 // XFAIL: libcpp-has-no-experimental-tzdb
 // XFAIL: availability-tzdb-missing
 
-// VE runs on CentOS 7 whose tzdata package does not include leap-seconds.list,
-// which libc++ requires for leap second data.
-// XFAIL: target=ve-{{.*}}
-
 // REQUIRES: locale.fr_FR.UTF-8
 // REQUIRES: locale.ja_JP.UTF-8
 


### PR DESCRIPTION
## Summary
- Remove VE XFAIL annotation from `gps_time.ostream.pass.cpp`
- Upstream commit a28755537b41 (`[libc++] Fix gps_time formatting and related tests (#181560)`) changed gps_time formatting to not consider leap seconds, so the test no longer requires `leap-seconds.list` from tzdata
- The remaining 21 VE tzdata XFAILs are unaffected and still needed

## Test plan
- [x] `gps_time.ostream.pass.cpp` passes on VE (confirmed with single test run and full check-libcxx)